### PR TITLE
use an OS specific open dialog to get the right behavior

### DIFF
--- a/src/Modules/Repository/RepositoryModule.cpp
+++ b/src/Modules/Repository/RepositoryModule.cpp
@@ -83,13 +83,25 @@ void RepositoryModule::onRepositoryOpen()
 {
 	QWidget* main = MacGitver::self().mainWindow()->widget();
 
-	QString fn = QFileDialog::getExistingDirectory( main, trUtf8( "Open repository" ) );
-	if( fn.isEmpty() )
-	{
-		return;
-	}
+    QFileDialog *fd = new QFileDialog(main);
+#ifdef Q_OS_MAC
+    fd->setFilter(QDir::Dirs | QDir::NoDotAndDotDot | QDir::Hidden);
+#else
+    fd->setFileMode(QFileDialog::Directory);
+#endif
+    fd->setWindowTitle( trUtf8("Open a Git repository") );
+    fd->open(this, SLOT(onRepositoryOpenHelper()));
+}
 
-	Git::Repository repo = Git::Repository::open( fn );
+void RepositoryModule::onRepositoryOpenHelper()
+{
+    QFileDialog *fd = dynamic_cast<QFileDialog *>(sender());
+    Q_ASSERT(fd != 0);
+
+    if ( fd->selectedFiles().isEmpty() )
+        return;
+
+    Git::Repository repo = Git::Repository::open( fd->selectedFiles().first() );
 	if( repo.isValid() )
 	{
 		MacGitver::self().setRepository( repo );

--- a/src/Modules/Repository/RepositoryModule.cpp
+++ b/src/Modules/Repository/RepositoryModule.cpp
@@ -95,7 +95,7 @@ void RepositoryModule::onRepositoryOpen()
 
 void RepositoryModule::onRepositoryOpenHelper()
 {
-    QFileDialog *fd = dynamic_cast<QFileDialog *>(sender());
+    QFileDialog *fd = qobject_cast<QFileDialog *>(sender());
     Q_ASSERT(fd != 0);
 
     if ( fd->selectedFiles().isEmpty() )

--- a/src/Modules/Repository/RepositoryModule.h
+++ b/src/Modules/Repository/RepositoryModule.h
@@ -46,6 +46,10 @@ private slots:
 	void onRepositoryCreate();
 	void onRepositoryClone();
 	void onRepositoryOpen();
+    /**
+     * @brief Helper slot to open a git repository using an OS specific dialog.
+     */
+    void onRepositoryOpenHelper();
 	void onRepositoryClose();
 
 private:


### PR DESCRIPTION
Used it in MsPiggit to get the "sheet" dialog in OSX. But it also handles some difficulties in opening directories on different OS's named with a file extension (e.g. bare repositories with the ".git" extension).
