### PR TITLE
Repository: Remeber last opened repository

### DIFF
--- a/src/Modules/Repository/RepositoryModule.cpp
+++ b/src/Modules/Repository/RepositoryModule.cpp
@@ -25,6 +25,7 @@
 #include "CreateRepositoryDlg.h"
 
 RepositoryModule::RepositoryModule()
+	: ConfigUser( "Repository" )
 {
 	mCore = new RepositoryCore;
 }
@@ -89,7 +90,15 @@ void RepositoryModule::onRepositoryOpen()
 #else
 	fd->setFileMode(QFileDialog::Directory);
 #endif
+
+	QString lastUsedDir = configGet( "lastUsedDir", "#" );
+	if( lastUsedDir != QLatin1String( "#" ) )
+	{
+		fd->setDirectory( lastUsedDir );
+	}
+
 	fd->setWindowTitle( trUtf8("Open a Git repository") );
+
 	fd->open(this, SLOT(onRepositoryOpenHelper()));
 }
 
@@ -101,10 +110,16 @@ void RepositoryModule::onRepositoryOpenHelper()
 	if ( fd->selectedFiles().isEmpty() )
 		return;
 
-	Git::Repository repo = Git::Repository::open( fd->selectedFiles().first() );
+	QString dirName = fd->selectedFiles().first();
+
+	Git::Repository repo = Git::Repository::open( dirName );
 	if( repo.isValid() )
 	{
 		MacGitver::self().setRepository( repo );
+
+		// If we successfully loaded the repository at that directory,
+		// we store it as "lastUsedDir"
+		configSet( "lastUsedDir", dirName );
 	}
 }
 

--- a/src/Modules/Repository/RepositoryModule.h
+++ b/src/Modules/Repository/RepositoryModule.h
@@ -19,11 +19,13 @@
 
 #include "MacGitver/Module.h"
 
+#include "Config/ConfigUser.h"
+
 #include "hic_RepositoryModule.h"
 
 class RepositoryCore;
 
-class RepositoryModule : public Module, public RepositoryActions
+class RepositoryModule : public Module, public RepositoryActions, private ConfigUser
 {
 	Q_OBJECT
 	Q_PLUGIN_METADATA( IID "org.babbelbox.sacu.macgitver.IModule/0.1" FILE "Module.json" )
@@ -46,10 +48,10 @@ private slots:
 	void onRepositoryCreate();
 	void onRepositoryClone();
 	void onRepositoryOpen();
-    /**
-     * @brief Helper slot to open a git repository using an OS specific dialog.
-     */
-    void onRepositoryOpenHelper();
+	/**
+	 * @brief Helper slot to open a git repository using an OS specific dialog.
+	 */
+	void onRepositoryOpenHelper();
 	void onRepositoryClose();
 
 private:


### PR DESCRIPTION
Some OSes remember the last File-Dialog location on a per application
basis. But that means that different logical operations (Like 'Open
Repository' and 'Save patch to') share the same Last-Used location.
