### PR TITLE
implemented method Repository::discover() (take 2) 

### DIFF
--- a/src/Libs/GitWrap/Repository.cpp
+++ b/src/Libs/GitWrap/Repository.cpp
@@ -36,6 +36,8 @@
 #include "RevisionWalkerPrivate.h"
 #include "Submodule.h"
 
+#include <QFile>
+
 namespace Git
 {
 
@@ -124,8 +126,21 @@ namespace Git
 			return Repository();
 		}
 
-		return Repository( new RepositoryPrivate( repo ) );
-	}
+        return Repository( new RepositoryPrivate( repo ) );
+    }
+
+    QString Repository::discover(const QString& startPath, bool acrossFs, const QStringList& ceilingDirs)
+    {
+        QByteArray repoPath(GIT_PATH_MAX, Qt::Uninitialized);
+        QByteArray joinedCeilingDirs = QFile::encodeName( ceilingDirs.join(QChar::fromLatin1(GIT_PATH_LIST_SEPARATOR)) );
+
+        git_repository_discover( repoPath.data(), repoPath.length()
+                                 , QFile::encodeName(startPath).constData()
+                                 , acrossFs, joinedCeilingDirs.constData()
+                                 );
+
+        return QFile::decodeName(repoPath);
+    }
 
 	Repository Repository::open( const QString& path )
 	{

--- a/src/Libs/GitWrap/Repository.cpp
+++ b/src/Libs/GitWrap/Repository.cpp
@@ -36,8 +36,6 @@
 #include "RevisionWalkerPrivate.h"
 #include "Submodule.h"
 
-#include <QFile>
-
 namespace Git
 {
 
@@ -132,14 +130,14 @@ namespace Git
     QString Repository::discover(const QString& startPath, bool acrossFs, const QStringList& ceilingDirs)
     {
         QByteArray repoPath(GIT_PATH_MAX, Qt::Uninitialized);
-        QByteArray joinedCeilingDirs = QFile::encodeName( ceilingDirs.join(QChar::fromLatin1(GIT_PATH_LIST_SEPARATOR)) );
+        QByteArray joinedCeilingDirs = ceilingDirs.join(QChar::fromLatin1(GIT_PATH_LIST_SEPARATOR)).toUtf8();
 
         git_repository_discover( repoPath.data(), repoPath.length()
-                                 , QFile::encodeName(startPath).constData()
+                                 , QString(startPath).toUtf8().constData()
                                  , acrossFs, joinedCeilingDirs.constData()
                                  );
 
-        return QFile::decodeName(repoPath);
+        return QString::fromUtf8(repoPath.constData());
     }
 
 	Repository Repository::open( const QString& path )

--- a/src/Libs/GitWrap/Repository.h
+++ b/src/Libs/GitWrap/Repository.h
@@ -53,7 +53,33 @@ namespace Git
 
 	public:
 		static Repository create( const QString& path, bool bare );
-		static Repository open( const QString& path );
+
+        /**
+         * @brief Lookup a git repository by walking parent directories starting from startPath.
+         *
+         * The lookup ends when the first repository is found or when reaching one of the ceilingDirs directories.
+         *
+         * The method will automatically detect if the repository is bare (if there is a
+         * repository).
+         *
+         * @param startPath
+         * The base path where the lookup starts.
+         *
+         * @param acrossFs
+         * If true, then the lookup will not stop when a filesystem change is detected
+         * while exploring parent directories.
+         *
+         * @param ceilingDirs
+         * A list of absolute paths (no symbolic links). The lookup will stop when one of these
+         * paths is reached and no repository was found.
+         *
+         * @return the path of the found repository or an empty QString
+         */
+        static QString discover( const QString& startPath,
+                                 bool acrossFs = false,
+                                 const QStringList& ceilingDirs = QStringList() );
+
+        static Repository open( const QString& path );
 
 		bool isValid() const;
 		bool isBare() const;


### PR DESCRIPTION
fixed the discover method to use fromUtf8 / toUtf8 paths. could you please check it once more, as I am not 100% sure if it is correct. on the other hand, we'll notice it, if the first utf-8 path is used to discover a repo :smile:.
