### PR TITLE
Widgets: Add a "Flat" Tree Model, Delegate and ComboBox …

### DIFF
--- a/src/Libs/Widgets/CMakeLists.txt
+++ b/src/Libs/Widgets/CMakeLists.txt
@@ -15,6 +15,9 @@ SET( SRC_FILES
 	LineEdit.cpp
 	StringSelectorWidget.cpp
 	HeaderView.cpp
+	FlatTreeComboBox.cpp
+	FlatTreeModel.cpp
+	FlatTreeDelegate.cpp
 )
 
 SET( PUB_HDR_FILES
@@ -25,10 +28,14 @@ SET( PUB_HDR_FILES
 	LineEdit.h
 	StringSelectorWidget.h
 	HeaderView.h
+	FlatTreeComboBox.h
+	FlatTreeModel.h
+	FlatTreeDelegate.h
 )
 
 SET( PRI_HDR_FILES
 	StringSelectorWidgetPrivate.h
+	FlatTreeModelPrivate.h
 )
 
 SET( HDR_FILES ${PRI_HDR_FILES} ${PUB_HDR_FILES} )
@@ -47,6 +54,7 @@ TARGET_LINK_LIBRARIES(
 	Widgets
 
 	Config
+	GitWrap
 )
 
 INSTALL_MGV_LIB( Widgets )

--- a/src/Libs/Widgets/FlatTreeComboBox.cpp
+++ b/src/Libs/Widgets/FlatTreeComboBox.cpp
@@ -1,0 +1,64 @@
+/*
+ * MacGitver
+ * Copyright (C) 2012 Sascha Cunz <sascha@babbelbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QListView>
+
+#include "FlatTreeModelPrivate.h"
+#include "FlatTreeDelegate.h"
+#include "FlatTreeComboBox.h"
+
+FlatTreeComboBox::FlatTreeComboBox( QWidget* parent )
+	: QComboBox( parent )
+{
+	setModel( new FlatTreeModel( this ) );
+	QListView* lv = new QListView;
+	lv->setModel( model() );
+	lv->setItemDelegate( new FlatTreeDelegate( this ) );
+	setView( lv );
+}
+
+void FlatTreeComboBox::setModel( FlatTreeModel* model )
+{
+	QComboBox::setModel( model );
+}
+
+void FlatTreeComboBox::add( const QString& entry )
+{
+	FlatTreeModel* m = qobject_cast< FlatTreeModel* >( model() );
+	Q_ASSERT( m );
+	m->remove( entry );
+}
+
+void FlatTreeComboBox::add( const QStringList& entries )
+{
+	FlatTreeModel* m = qobject_cast< FlatTreeModel* >( model() );
+	Q_ASSERT( m );
+	m->add( entries );
+}
+
+void FlatTreeComboBox::remove( const QString& entry )
+{
+	FlatTreeModel* m = qobject_cast< FlatTreeModel* >( model() );
+	Q_ASSERT( m );
+	m->remove( entry );
+}
+
+void FlatTreeComboBox::remove( const QStringList& entries )
+{
+	FlatTreeModel* m = qobject_cast< FlatTreeModel* >( model() );
+	Q_ASSERT( m );
+	m->remove( entries );
+}

--- a/src/Libs/Widgets/FlatTreeComboBox.h
+++ b/src/Libs/Widgets/FlatTreeComboBox.h
@@ -1,0 +1,42 @@
+/*
+ * MacGitver
+ * Copyright (C) 2012 Sascha Cunz <sascha@babbelbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MGV_FLAT_TREE_COMBOBOX_H
+#define MGV_FLAT_TREE_COMBOBOX_H
+
+#include "Widgets/WidgetsApi.h"
+
+#include <QComboBox>
+
+class FlatTreeModel;
+
+class WIDGETS_API FlatTreeComboBox : public QComboBox
+{
+	Q_OBJECT
+public:
+	FlatTreeComboBox( QWidget* parent = 0 );
+
+public:
+	void setModel( FlatTreeModel* model );
+
+	void add( const QString& entry );
+	void add( const QStringList& entries );
+
+	void remove( const QString& entry );
+	void remove( const QStringList& entries );
+};
+
+#endif

--- a/src/Libs/Widgets/FlatTreeDelegate.cpp
+++ b/src/Libs/Widgets/FlatTreeDelegate.cpp
@@ -1,0 +1,91 @@
+/*
+ * MacGitver
+ * Copyright (C) 2012 Sascha Cunz <sascha@babbelbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QPainter>
+
+#include "FlatTreeModelPrivate.h"
+#include "FlatTreeDelegate.h"
+
+FlatTreeDelegate::FlatTreeDelegate( QObject* parent )
+	: QItemDelegate( parent )
+{
+}
+
+void FlatTreeDelegate::paint( QPainter* painter, const QStyleOptionViewItem& option,
+							  const QModelIndex& index ) const
+{
+	const FlatTreeModel* model = qobject_cast< const FlatTreeModel* >( index.model() );
+	if( !model )
+	{
+		QItemDelegate::paint( painter, option, index );
+	}
+
+	drawBackground( painter, option, index );
+
+	QFont f = option.font;
+	if( index.data( Qt::UserRole + 1 ).toBool() )
+	{
+		f.setBold( true );
+	}
+
+	int left = (index.data( Qt::UserRole + 2 ).toInt()-1) * 18;
+
+	QRect rect = option.rect.adjusted( left, 0, 0, 0 );
+
+	QIcon icon = index.data( Qt::DecorationRole ).value< QIcon >();
+	if( !icon.isNull() )
+	{
+		QRect iconRect = rect;
+		iconRect.setWidth( 16 );
+		icon.paint( painter, iconRect, Qt::AlignVCenter );
+		rect.adjust( 18, 0, 0, 0 );
+	}
+
+	rect.adjust( 1, 1, -1, -1 );
+	painter->setFont( f );
+	painter->drawText( rect, Qt::AlignLeft | Qt::AlignVCenter,
+					   index.data( Qt::UserRole + 3 ).toString() );
+
+	rect = option.rect.adjusted( left, 0, 0, 0 );
+	drawFocus( painter, option, rect );
+}
+
+QSize FlatTreeDelegate::sizeHint( const QStyleOptionViewItem& option,
+								  const QModelIndex& index ) const
+{
+	const FlatTreeModel* model = qobject_cast< const FlatTreeModel* >( index.model() );
+	if( !model )
+	{
+		return QItemDelegate::sizeHint( option, index );
+	}
+
+	QFont f = option.font;
+	if( index.data( Qt::UserRole + 1 ).toBool() )
+	{
+		f.setBold( true );
+	}
+	QFontMetrics fm( f );
+
+	int left = (index.data( Qt::UserRole + 2 ).toInt()-1) * 18;
+
+	if( !index.data( Qt::DecorationRole ).value< QIcon >().isNull() )
+	{
+		left += 18;
+	}
+
+	QString s = index.data( Qt::UserRole + 3 ).toString();
+	return QSize( left + fm.width( s ), qMax( 18, fm.lineSpacing() + 2 ) );
+}

--- a/src/Libs/Widgets/FlatTreeDelegate.h
+++ b/src/Libs/Widgets/FlatTreeDelegate.h
@@ -1,0 +1,34 @@
+/*
+ * MacGitver
+ * Copyright (C) 2012 Sascha Cunz <sascha@babbelbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MGV_FLAT_TREE_DELEGATE_H
+#define MGV_FLAT_TREE_DELEGATE_H
+
+#include "Widgets/WidgetsApi.h"
+
+#include <QItemDelegate>
+
+class WIDGETS_API FlatTreeDelegate : public QItemDelegate
+{
+	Q_OBJECT
+public:
+	FlatTreeDelegate( QObject* parent );
+public:
+	void paint( QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index ) const;
+	QSize sizeHint( const QStyleOptionViewItem& option, const QModelIndex& index ) const;
+}; 
+
+#endif

--- a/src/Libs/Widgets/FlatTreeModel.cpp
+++ b/src/Libs/Widgets/FlatTreeModel.cpp
@@ -1,0 +1,354 @@
+/*
+ * MacGitver
+ * Copyright (C) 2012 Sascha Cunz <sascha@babbelbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QStringList>
+
+#include "FlatTreeModelPrivate.h"
+
+FlatTreeModelPrivate::FlatTreeModelPrivate( FlatTreeModel* owner )
+{
+	mOwner = owner;
+	mSeparator = QChar( L'/' );
+	mRoot.mParent = mRoot.mFirstChild = mRoot.mNextSibling = NULL;
+}
+
+FlatTreeModelEntry* FlatTreeModelPrivate::entryByPath( const QString& path )
+{
+	QStringList remainder;
+	FlatTreeModelEntry* entry = entryByPath( path, remainder );
+	return remainder.count() ? NULL : entry;
+}
+
+FlatTreeModelEntry* FlatTreeModelPrivate::entryByPath( const QString& path, QStringList& remainder )
+{
+	remainder = path.split( mSeparator );
+	return subEntry( &mRoot, remainder );
+}
+
+FlatTreeModelEntry* FlatTreeModelPrivate::subEntry( FlatTreeModelEntry* parent,
+													QStringList& remainder )
+{
+	Q_ASSERT( parent );
+
+	if( remainder.count() == 0 )
+	{
+		return parent;
+	}
+
+	QString me = remainder.at( 0 );
+
+	FlatTreeModelEntry* cur = parent->mFirstChild;
+	while( cur )
+	{
+		if( cur->mText == me )
+		{
+			remainder.removeFirst();
+			return subEntry( cur, remainder );
+		}
+
+		cur = cur->mNextSibling;
+	}
+
+	return parent;
+}
+
+int FlatTreeModelPrivate::updateIndicies( FlatTreeModelEntry* cur, int& currentIndex,
+										  int level, FlatTreeModelEntry* search )
+{
+	int found = -1;
+	while( cur )
+	{
+		cur->mIndex = currentIndex++;
+		cur->mLevel = level;
+		if( cur == search )
+			found = cur->mIndex;
+
+		if( cur->mFirstChild )
+		{
+			int i = updateIndicies( cur->mFirstChild, currentIndex, level + 1, search );
+			if( found == -1 )
+				found = i;
+		}
+
+		cur = cur->mNextSibling;
+	}
+
+	return found;
+}
+
+bool FlatTreeModelPrivate::addEntry( const QString& path )
+{
+	QStringList remainder = path.split( mSeparator );
+	FlatTreeModelEntry* cur = subEntry( &mRoot, remainder );
+
+	if( remainder.count() == 0 )
+	{
+		return false;
+	}
+
+	while( remainder.count() )
+	{
+		FlatTreeModelEntry* newEntry = new FlatTreeModelEntry;
+		newEntry->mFirstChild = NULL;
+		newEntry->mParent = cur;
+		
+		if( cur->mFirstChild )
+		{
+			FlatTreeModelEntry** ppar = &cur->mFirstChild;
+			while( *ppar && (*ppar)->mText < remainder.at(0) )
+				ppar = &(*ppar)->mNextSibling;
+			newEntry->mNextSibling = *ppar;
+			*ppar = newEntry;
+		}
+		else
+		{
+			newEntry->mNextSibling = cur->mFirstChild;
+			cur->mFirstChild = newEntry;
+		}
+
+		newEntry->mIsHeader = remainder.count() > 1;
+		newEntry->mText = remainder.takeFirst();
+
+		int curIdx = -1;
+		int idx = updateIndicies( &mRoot, curIdx, 0, newEntry );
+		mOwner->beginInsertRows( QModelIndex(), idx, idx );
+		mEntries.insert( idx, newEntry );
+		mOwner->endInsertRows();
+
+		cur = newEntry;
+	}
+
+	cur->mPath = path;
+
+	return true;
+}
+
+bool FlatTreeModelPrivate::rawRemove( FlatTreeModelEntry* entry )
+{
+	Q_ASSERT( entry && entry->mFirstChild == NULL );
+
+	if( entry == &mRoot )
+		return false;
+
+	FlatTreeModelEntry* parent = entry->mParent;
+	FlatTreeModelEntry** ppcur = &parent->mFirstChild;
+	while( *ppcur )
+	{
+		if( *ppcur == entry )
+		{
+			*ppcur = entry->mNextSibling;
+
+			mOwner->beginRemoveRows( QModelIndex(), entry->mIndex, entry->mIndex );
+			mEntries.removeAt( entry->mIndex );
+			mOwner->endRemoveRows();
+
+			int curIdx = -1;
+			updateIndicies( &mRoot, curIdx, 0, NULL );
+
+			delete entry;
+
+			if( parent->mFirstChild == NULL && parent != &mRoot )
+			{
+				return rawRemove( parent );
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool FlatTreeModelPrivate::removeEntry( const QString& entry )
+{
+	QStringList remainder = entry.split( mSeparator );
+	FlatTreeModelEntry* cur = subEntry( &mRoot, remainder );
+
+	if( remainder.count() != 0 )
+	{
+		return false;
+	}
+
+	return rawRemove( cur );
+}
+
+FlatTreeModelPrivate::~FlatTreeModelPrivate()
+{
+	qDeleteAll( mEntries );
+}
+
+FlatTreeModel::FlatTreeModel( QObject* parent )
+	: QAbstractListModel( parent )
+{
+	d = new FlatTreeModelPrivate( this );
+}
+
+FlatTreeModel::FlatTreeModel( const QStringList& entries, QObject* parent )
+	: QAbstractListModel( parent )
+{
+	d = new FlatTreeModelPrivate( this );
+	add( entries );
+}
+
+FlatTreeModel::FlatTreeModel( const QChar separator, const QStringList& entries, QObject* parent )
+	: QAbstractListModel( parent )
+{
+	d = new FlatTreeModelPrivate( this );
+	d->mSeparator = separator;
+	add( entries );
+}
+
+FlatTreeModel::~FlatTreeModel()
+{
+	delete d;
+}
+
+void FlatTreeModel::add( const QStringList& entries )
+{
+	foreach( QString s, entries )
+	{
+		add( s );
+	}
+}
+
+void FlatTreeModel::remove( const QStringList& entries )
+{
+	foreach( QString s, entries )
+	{
+		remove( s );
+	}
+}
+
+void FlatTreeModel::add( const QString& entry )
+{
+	d->addEntry( entry );
+}
+
+void FlatTreeModel::remove( const QString& entry )
+{
+	d->removeEntry( entry );
+}
+
+int FlatTreeModel::rowCount( const QModelIndex& parent ) const
+{
+	return parent.isValid() ? 0 : d->mEntries.count();
+}
+
+QVariant FlatTreeModel::data( const QModelIndex& index, int role ) const
+{
+	if( !index.isValid() || index.column() != 0 || index.row() >= d->mEntries.count() )
+	{
+		return QVariant();
+	}
+
+	FlatTreeModelEntry* entry = d->mEntries.at( index.row() );
+
+	switch( role )
+	{
+	case Qt::DisplayRole:
+		return entry->mPath;
+
+	case Qt::DecorationRole:
+		if( entry->mIcon.isNull() )
+		{
+			return entry->mIsHeader ? d->mDefaultHeaderIcon
+									: d->mDefaultEntryIcon;
+		}
+		return entry->mIcon;
+
+	case Qt::UserRole:
+		return entry->mUserData;
+
+	case Qt::UserRole + 1:
+		return entry->mIsHeader;
+
+	case Qt::UserRole + 2:
+		return entry->mLevel;
+
+	case Qt::UserRole + 3:
+		return entry->mText;
+
+	default:
+		return QVariant();
+	}
+}
+
+bool FlatTreeModel::setData( const QModelIndex& index, const QVariant& value, int role )
+{
+	if( !index.isValid() || index.column() != 0 || index.row() >= d->mEntries.count() )
+	{
+		return false;
+	}
+
+	FlatTreeModelEntry* entry = d->mEntries.at( index.row() );
+	switch( role )
+	{
+	case Qt::DisplayRole:
+		qDebug( "Cannot change a FlatTreeModelEntry's path" );
+		return false;
+
+	case Qt::DecorationRole:
+		entry->mIcon = value.value< QIcon >();
+		emit dataChanged( index, index );
+		return true;
+
+	case Qt::UserRole:
+		entry->mUserData = value;
+		return true;
+
+	default:
+		qDebug( "Wrong role given to FlatTreeModel::setData" );
+		return false;
+	}
+}
+
+Qt::ItemFlags FlatTreeModel::flags( const QModelIndex& index ) const
+{
+	if( !index.isValid() || index.column() != 0 || index.row() >= d->mEntries.count() )
+	{
+		return Qt::NoItemFlags;
+	}
+
+	FlatTreeModelEntry* entry = d->mEntries.at( index.row() );
+
+	if( entry->mIsHeader )
+		return Qt::ItemIsEnabled;
+	else
+		return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+}
+
+QIcon FlatTreeModel::defaultHeaderIcon() const
+{
+	return d->mDefaultHeaderIcon;
+}
+
+QIcon FlatTreeModel::defaultDataIcon() const
+{
+	return d->mDefaultEntryIcon;
+}
+
+void FlatTreeModel::setDefaultHeaderIcon( const QIcon& icon )
+{
+	beginResetModel();
+	d->mDefaultHeaderIcon = icon;
+	endResetModel();
+}
+
+void FlatTreeModel::setDefaultDataIcon( const QIcon& icon )
+{
+	beginResetModel();
+	d->mDefaultEntryIcon = icon;
+	endResetModel();
+}

--- a/src/Libs/Widgets/FlatTreeModel.h
+++ b/src/Libs/Widgets/FlatTreeModel.h
@@ -1,0 +1,58 @@
+/*
+ * MacGitver
+ * Copyright (C) 2012 Sascha Cunz <sascha@babbelbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MGV_FLAT_TREE_MODEL_H
+#define MGV_FLAT_TREE_MODEL_H
+
+#include "Widgets/WidgetsApi.h"
+
+#include <QAbstractListModel>
+
+class FlatTreeModelPrivate;
+class WIDGETS_API FlatTreeModel : public QAbstractListModel
+{
+	friend class FlatTreeModelPrivate;
+	Q_OBJECT
+public:
+	explicit FlatTreeModel( QObject* parent = 0 );
+	FlatTreeModel( const QStringList& entries, QObject* parent = 0 );
+	FlatTreeModel( const QChar separator, const QStringList& entries, QObject* parent = 0 );
+	~FlatTreeModel();
+
+public:
+	void add( const QString& entry );
+	void add( const QStringList& entries );
+
+	void remove( const QString& entry );
+	void remove( const QStringList& entries );
+
+	QIcon defaultHeaderIcon() const;
+	QIcon defaultDataIcon() const;
+
+	void setDefaultHeaderIcon( const QIcon& icon );
+	void setDefaultDataIcon( const QIcon& icon );
+
+public:
+	int rowCount( const QModelIndex& parent ) const;
+	QVariant data( const QModelIndex& index, int role ) const;
+	bool setData( const QModelIndex& index, const QVariant& value, int role );
+	Qt::ItemFlags flags( const QModelIndex& index ) const;
+
+private:
+	FlatTreeModelPrivate* d;
+};
+
+#endif

--- a/src/Libs/Widgets/FlatTreeModelPrivate.h
+++ b/src/Libs/Widgets/FlatTreeModelPrivate.h
@@ -1,0 +1,66 @@
+/*
+ * MacGitver
+ * Copyright (C) 2012 Sascha Cunz <sascha@babbelbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MGV_FLAT_TREE_MODEL_PRIVATE_H
+#define MGV_FLAT_TREE_MODEL_PRIVATE_H
+
+#include <QIcon>
+#include <QVariant>
+
+#include "FlatTreeModel.h"
+
+struct FlatTreeModelEntry
+{
+	QIcon				mIcon;
+	QString				mText;
+	QString				mPath;
+	QVariant			mUserData;
+	bool				mIsHeader;
+	int					mIndex;
+	int					mLevel;
+	FlatTreeModelEntry*	mParent;
+	FlatTreeModelEntry*	mFirstChild;
+	FlatTreeModelEntry*	mNextSibling;
+};
+
+class FlatTreeModelPrivate
+{
+public:
+	FlatTreeModelPrivate( FlatTreeModel* owner );
+	~FlatTreeModelPrivate();
+
+public:
+	FlatTreeModelEntry* entryByPath( const QString& path );
+	FlatTreeModelEntry* entryByPath( const QString& path, QStringList& remainder );
+	FlatTreeModelEntry* subEntry( FlatTreeModelEntry* parent, QStringList& remainder );
+	int updateIndicies( FlatTreeModelEntry* cur, int& currentIndex,
+						int level, FlatTreeModelEntry* search );
+
+	bool addEntry( const QString& path );
+	bool removeEntry( const QString& path );
+
+	bool rawRemove( FlatTreeModelEntry* entry );
+
+public:
+	FlatTreeModel*					mOwner;
+	QChar							mSeparator;
+	QIcon							mDefaultHeaderIcon;
+	QIcon							mDefaultEntryIcon;
+	QList< FlatTreeModelEntry* >	mEntries;
+	FlatTreeModelEntry				mRoot;
+};
+
+#endif


### PR DESCRIPTION
Well, long time ago somebody told me, inventing wheels from scratch was
useless spent time. So, I'm always trying to invent something new; and
here we go again: Let me proudly introduce "flat trees" to the world...
:-)

This is a QAbstractItemModel that takes a list of strings and separates
each of them by a char. Segments are taken as nodes in a tree. Just like
a filesystem does. Items are than flatly stored inside a list
(internally keeping a tree, of course). The non-leaves are declared
"headers" and not selectable; the leaves are selectable.

The delegate draws this structure as a edge-less tree, forming a flat
looking hierarchy. A CombBox is provided that will set up a QListView as
drop down view.
