### PR TITLE
Submodule UI Module: The next step

### DIFF
--- a/src/Modules/Submodules/CMakeLists.txt
+++ b/src/Modules/Submodules/CMakeLists.txt
@@ -14,6 +14,7 @@ SET( SRC_FILES
     SubmodulesCreateEditDlg.cpp
     SubmodulesModule.cpp
     SubmodulesView.cpp
+    SubmodulesDelegate.cpp
 )
 
 SET( HDR_FILES
@@ -21,6 +22,7 @@ SET( HDR_FILES
     SubmodulesCreateEditDlg.h
     SubmodulesModule.h
     SubmodulesView.h
+    SubmodulesDelegate.h
 )
 
 SET( UI_FILES

--- a/src/Modules/Submodules/SubmodulesDelegate.cpp
+++ b/src/Modules/Submodules/SubmodulesDelegate.cpp
@@ -1,0 +1,100 @@
+#include "SubmodulesDelegate.h"
+
+#include <QAbstractItemView>
+#include <QPainter>
+#include <QToolTip>
+#include <QHelpEvent>
+
+#include "libGitWrap/ObjectId.h"
+#include "libGitWrap/Submodule.h"
+
+
+SubmodulesViewDelegate::SubmodulesViewDelegate( QObject* parent )
+    : QItemDelegate( parent )
+{
+}
+
+void SubmodulesViewDelegate::paint( QPainter* painter, const QStyleOptionViewItem& option,
+                                    const QModelIndex& index ) const
+{
+    if( index.column() != 0 )
+    {
+        QItemDelegate::paint( painter, option, index );
+        return;
+    }
+
+    drawBackground( painter, option, index );
+
+    drawDisplay( painter, option, option.rect.adjusted( 1, 1, -1, -1 ), index );
+
+    QIcon theDecoration( index.data(Qt::DecorationRole).value<QIcon>() );
+    QRect decorationRect(QPoint(0, 0), option.decorationSize);
+    if ( option.decorationAlignment.testFlag(Qt::AlignVCenter) )
+    {
+        QPoint newCenter( decorationRect.center().x(), option.rect.center().y() );
+        decorationRect.moveCenter( newCenter );
+    }
+    QItemDelegate::drawDecoration( painter, option, decorationRect, theDecoration.pixmap(decorationRect.size()) );
+
+    drawFocus( painter, option, option.rect );
+}
+
+void SubmodulesViewDelegate::drawDisplay(QPainter *painter, const QStyleOptionViewItem &option,
+                                         const QRect &rect, const QModelIndex &index) const
+{
+    const QFontMetrics& fm = option.fontMetrics;
+
+    QRect textRect = option.rect;
+    textRect.moveLeft( option.decorationSize.width() );
+    textRect.setBottom( textRect.top() + fm.lineSpacing() );
+
+    const QVariant &submoduleData = index.data(Qt::UserRole + 1);
+    if ( submoduleData.canConvert<Git::Submodule>() )
+    {
+        const Git::Submodule &submodule = index.data(Qt::UserRole + 1).value<Git::Submodule>();
+
+        QFont f( option.font );
+        f.setBold( true );
+        painter->setFont( f );
+        painter->drawText( textRect, trUtf8("Name: %1").arg(submodule.name()) );
+
+        textRect.moveTop( textRect.top() + fm.lineSpacing() );
+        painter->setFont( option.font );
+        painter->drawText( textRect, trUtf8("Revision: %1").arg(submodule.currentSHA1().toString()) );
+    }
+}
+
+bool SubmodulesViewDelegate::helpEvent(QHelpEvent *event, QAbstractItemView *view,
+                                       const QStyleOptionViewItem &option, const QModelIndex &index)
+{
+    if ( !event || !view )
+        return false;
+
+    const QVariant &submoduleData = index.data(Qt::UserRole + 1);
+    if ( !submoduleData.canConvert<Git::Submodule>() )
+        return false;
+
+    const Git::Submodule &submodule = index.data(Qt::UserRole + 1).value<Git::Submodule>();
+
+    if ( event->type() == QEvent::ToolTip )
+    {
+        QString tooltip =
+                trUtf8("URL: %1\nPath: %2")
+                .arg(submodule.url())
+                .arg(submodule.path());
+
+        QToolTip::showText( event->globalPos(), tooltip, view );
+
+        return true;
+    }
+
+    return QItemDelegate::helpEvent( event, view, option, index );
+}
+
+QSize SubmodulesViewDelegate::sizeHint( const QStyleOptionViewItem& option,
+                                        const QModelIndex& index ) const
+{
+    const QFontMetrics& fm = option.fontMetrics;
+
+    return QSize( 200, 2 + 2 * fm.lineSpacing() );
+}

--- a/src/Modules/Submodules/SubmodulesDelegate.h
+++ b/src/Modules/Submodules/SubmodulesDelegate.h
@@ -1,0 +1,33 @@
+#ifndef SUBMODULESDELEGATE_H
+#define SUBMODULESDELEGATE_H
+
+#include <QItemDelegate>
+
+/**
+ * @brief The SubmodulesViewDelegate class
+ */
+class SubmodulesViewDelegate : public QItemDelegate
+{
+    Q_OBJECT
+public:
+    SubmodulesViewDelegate( QObject* parent );
+
+public:
+    void paint( QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index ) const;
+    QSize sizeHint( const QStyleOptionViewItem& option, const QModelIndex& index ) const;
+
+    /**
+     * @brief Internal function to draw the item.
+     * @param painter
+     * @param option
+     * @param rect
+     * @param index
+     */
+    inline void drawDisplay(QPainter *painter, const QStyleOptionViewItem &option, const QRect &rect, const QModelIndex &index) const;
+
+public slots:
+    bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index);
+
+};
+
+#endif // SUBMODULESDELEGATE_H

--- a/src/Modules/Submodules/SubmodulesView.cpp
+++ b/src/Modules/Submodules/SubmodulesView.cpp
@@ -14,11 +14,7 @@
  *
  */
 
-#include <QStringBuilder>
-#include <QFontMetrics>
-#include <QPainter>
 #include <QVBoxLayout>
-#include <QItemDelegate>
 #include <QStandardItemModel>
 #include <QToolBar>
 #include <QTreeView>
@@ -29,62 +25,9 @@
 #include "MacGitver/FSWatcher.h"
 
 #include "SubmodulesView.h"
+#include "SubmodulesDelegate.h"
 #include "SubmodulesCreateEditDlg.h"
 
-
-class SubmodulesViewDelegate : public QItemDelegate
-{
-public:
-    SubmodulesViewDelegate( QObject* parent );
-public:
-    void paint( QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index ) const;
-    QSize sizeHint( const QStyleOptionViewItem& option, const QModelIndex& index ) const;
-
-};
-
-
-SubmodulesViewDelegate::SubmodulesViewDelegate( QObject* parent )
-    : QItemDelegate( parent )
-{
-}
-
-void SubmodulesViewDelegate::paint( QPainter* painter, const QStyleOptionViewItem& option,
-                                    const QModelIndex& index ) const
-{
-    const QFontMetrics& fm = option.fontMetrics;
-    if( index.column() != 0 )
-    {
-        QItemDelegate::paint( painter, option, index );
-        return;
-    }
-
-    drawBackground( painter, option, index );
-
-    QRect textRect = option.rect.adjusted( 1, 1, -1, -1 );
-
-    textRect.setBottom( textRect.top() + fm.lineSpacing() );
-    QFont f( option.font );
-    f.setBold( true );
-    painter->setFont( f );
-    painter->drawText( textRect, index.data().toString() );
-
-    textRect.moveTop( textRect.top() + fm.lineSpacing() );
-    painter->setFont( option.font );
-    painter->drawText( textRect,
-                       index.data( Qt::UserRole + 2 ).toString() %
-                       QLatin1String( " - " ) %
-                       index.data( Qt::UserRole + 1 ).toString() );
-
-    drawFocus( painter, option, option.rect );
-}
-
-QSize SubmodulesViewDelegate::sizeHint( const QStyleOptionViewItem& option,
-                                        const QModelIndex& index ) const
-{
-    const QFontMetrics& fm = option.fontMetrics;
-
-    return QSize( 200, 2 + 2 * fm.lineSpacing() );
-}
 
 SubmodulesView::SubmodulesView()
     : GlobalView( QLatin1String( "Submodules" ) )

--- a/src/Modules/Submodules/SubmodulesView.h
+++ b/src/Modules/Submodules/SubmodulesView.h
@@ -29,6 +29,7 @@ class QStandardItem;
 class QStandardItemModel;
 class QTreeView;
 
+
 class SubmodulesView : public Heaven::GlobalView, private SubmodulesViewActions
 {
     Q_OBJECT
@@ -45,7 +46,6 @@ private:
     Git::Repository                     mRepo;
     QTreeView*                          mTree;
     QStandardItemModel*                 mModel;
-    QHash< QString, QStandardItem* >    mNameToItem;
 };
 
 #endif


### PR DESCRIPTION
Finally I found some time to give the submodule view another try. I kept the "Novice.GUI.xml" file  local, so nothing is visible yet.

Features:
- reading of submodules in bare and normal repositories works
- ToolTip shows submodule details (URL and local relative path)

Missing:
- Because the IconProvider is not finished yet, an empty QIcon is used as a placeholder.
- As well,   submodules are not read recursively.
- The current submodule status.
- instead of the ID something like "git describe" should be shown (meaning: a tag, if there is one)

Questions:
- What was the intention of the (unused) visitor pattern in "readSubmodules()"? I'd suggest to leave it out, until we really need such a thing and do the right thing then.
- To make it work, I really had to take out the "LIBGIT2_IMPROVED" workaround. Otherwise nothing will be shown. Seems very ok to me. What do you think.
