### PR TITLE
Rewrite history detail view

### DIFF
--- a/History/HistoryDetails.cpp
+++ b/History/HistoryDetails.cpp
@@ -14,8 +14,6 @@
  *
  */
 
-#include <QPainter>
-
 #include "libMacGitverCore/Config/Config.h"
 
 #include "libGitWrap/ObjectCommit.hpp"

--- a/History/HistoryDetails.cpp
+++ b/History/HistoryDetails.cpp
@@ -56,6 +56,52 @@ void HistoryDetails::readConfig()
     setCommit( mCurrentSHA1 );
 }
 
+void HistoryDetails::setRepository( Git::Repository repo )
+{
+    mRepo = repo;
+    clear();
+}
+
+void HistoryDetails::clear()
+{
+    mCurrentSHA1 = Git::ObjectId();
+    setHtml( QString() );
+}
+
+void HistoryDetails::setCommit( const Git::ObjectId& sha1 )
+{
+    if( mCurrentSHA1 != sha1 )
+    {
+        mCurrentSHA1 = sha1;
+        updateText();
+    }
+}
+
+static inline QString mkRow( const QString& lbl, const QString& content, bool fixed = false )
+{
+    QString s = QLatin1String(
+                "<tr>"
+                    "<td style=\"font-weight:bold;\">"
+                        "%1:"
+                    "</td>"
+                    "<td%3>"
+                        "%2"
+                    "</td>"
+                "</tr>" );
+
+    QString styleAdd;
+    if( fixed )
+    {
+        QFont fixed = Config::self().defaultFixedFont();
+        styleAdd = QString( QLatin1String( " style=\"font-family: '%1';font-size: %2pt\"" ) )
+                .arg( fixed.family() )
+                .arg( fixed.pointSize() );
+
+    }
+
+    return s.arg( lbl ).arg( content ).arg( styleAdd );
+}
+
 void HistoryDetails::updateText()
 {
     Git::Result r;

--- a/History/HistoryDetails.h
+++ b/History/HistoryDetails.h
@@ -20,7 +20,7 @@
 #include "libGitWrap/ObjectId.hpp"
 #include "libGitWrap/Repository.hpp"
 
-#include <QAbstractScrollArea>
+#include <QTextBrowser>
 
 enum HistoryHeaderDetails
 {
@@ -38,7 +38,7 @@ enum HistoryHeaderDetails
     HHD_ParentsList
 };
 
-class HistoryDetails : public QAbstractScrollArea
+class HistoryDetails : public QTextBrowser
 {
     Q_OBJECT
 public:
@@ -47,51 +47,16 @@ public:
 public:
     void setRepository( Git::Repository repo );
     void setCommit( const Git::ObjectId& sha1 );
+    void clear();
 
 private:
-    void calculate();
-
-protected:
-    void paintEvent( QPaintEvent* ev );
-    void resizeEvent( QResizeEvent* ev );
-    void mouseMoveEvent( QMouseEvent* ev );
-    void mousePressEvent( QMouseEvent* ev );
-    void mouseReleaseEvent( QMouseEvent* ev );
-
-public:
-    void clear();
+    void updateText();
     void readConfig();
 
 private:
-    struct HeaderEntry
-    {
-        HeaderEntry( const QString& param, const QString& value, bool fixed = false )
-            : mParameter( param )
-            , mValue( value )
-            , mFixedFont( fixed )
-            , mHovered( false )
-        {
-        }
-
-        QString mParameter;
-        QString mValue;
-        QRect   mValueRect;
-        bool    mFixedFont  : 1;
-        bool    mHovered    : 1;
-    };
-
-    typedef QList< HeaderEntry > HeaderEntries;
-
-    QString                         mTitle;
     Git::ObjectId                   mCurrentSHA1;
-    HeaderEntries                   mHeaders;
-    QStringList                     mDetails;
-    QRect                           mDetailsRect;
-    QRect                           mHeader;
-    int                             mParamNameWidth;
     Git::Repository                 mRepo;
     QList< HistoryHeaderDetails >   mViewDetailRows;
-    bool                            mViewDetails : 1;
 };
 
 #endif


### PR DESCRIPTION
This change is a total rewrite of the current history view.

Instead of drawing it all ourselves, setup some HTML and show that in a
browser. This addresses most of the details related topics in
macgitver/MacGitver#3:
- Details view becomes scrollable
- Details view becomes selectable
- Lineheight for fixed-font header lines is fixed.

Snapshot from a Linux and Qt4 based build:
![History_Details](https://f.cloud.github.com/assets/1700771/238985/1a65e14e-8852-11e2-8219-9eb7347e7912.png)
