### PR TITLE
unstage files

### DIFF
--- a/WorkingTree/IndexTreeItemView.cpp
+++ b/WorkingTree/IndexTreeItemView.cpp
@@ -87,8 +87,7 @@ void IndexTreeItemView::onWtCtxUnstage()
     }
     else
     {
-        // TODO: Update status of index entry
-        QMessageBox::critical( 0, trUtf8("TODO"), trUtf8("Not implemented yet.") );
+        i.resetDefault( QStringList( itemPath ), r );
     }
     i.write( r );
 

--- a/WorkingTree/IndexTreeItemView.cpp
+++ b/WorkingTree/IndexTreeItemView.cpp
@@ -91,6 +91,9 @@ void IndexTreeItemView::onWtCtxUnstage()
     }
     i.write( r );
 
+    // TODO: workaround to update the model
+    mModel->setRepository(repo);
+
     if ( !r )
     {
         QMessageBox::warning( this, trUtf8("Error while unstaging file."),

--- a/WorkingTree/WorkingTreeCtxMenu.hid
+++ b/WorkingTree/WorkingTreeCtxMenu.hid
@@ -23,9 +23,9 @@ Ui WorkingTreeCtxMenu {
     };
 
     Action Reset {
-        Text            "&Reset changes";
-        StatusToolTip   "Reset all current changes to this file.";
-        ConnectTo       onWtCtxReset();
+        Text            "&Discard changes";
+        StatusToolTip   "Discard unstaged changes to this file.";
+        ConnectTo       onWtCtxDiscard();
     };
 
     Menu CtxMenuWtFile {

--- a/WorkingTree/WorkingTreeItemView.cpp
+++ b/WorkingTree/WorkingTreeItemView.cpp
@@ -84,6 +84,9 @@ void WorkingTreeItemView::onWtCtxStage()
     i.addEntry( item->path(), r );
     i.write( r );
 
+    // TODO: workaround to update the model
+    mModel->setRepository(repo);
+
     if ( !r )
     {
         QMessageBox::warning( this, trUtf8("Error while adding file to Git index"),

--- a/WorkingTree/WorkingTreeItemView.cpp
+++ b/WorkingTree/WorkingTreeItemView.cpp
@@ -94,7 +94,7 @@ void WorkingTreeItemView::onWtCtxStage()
     }
 }
 
-void WorkingTreeItemView::onWtCtxReset()
+void WorkingTreeItemView::onWtCtxDiscard()
 {
     // TODO: Reset file changes.
 }

--- a/WorkingTree/WorkingTreeItemView.h
+++ b/WorkingTree/WorkingTreeItemView.h
@@ -36,7 +36,7 @@ public:
 private slots:
     // hid actions
     void onWtCtxStage();
-    void onWtCtxReset();
+    void onWtCtxDiscard();
 
     void contextMenu(const QModelIndex &index, const QPoint &globalPos);
 


### PR DESCRIPTION
Unstaging of untracked files, which are new to the index is a simple `index.remove();`. This will mark the file as untracked.

To unstage modified files, we need to set the mode in  `IndexEntry` and after that update the index by `addEntry(modifiedEntry)`. Here the copied struct hurts of course, because we need to convert it to a `git_index_entry` (maybe with something like `indexEntry.toRawEntry()`). Any ideas how to do it right?
