### PR TITLE
Improvements to repository tree

### DIFF
--- a/Repository/RepoInfoModel.cpp
+++ b/Repository/RepoInfoModel.cpp
@@ -145,3 +145,11 @@ QModelIndex RepoInfoModel::info2Index( RepositoryInfo* info ) const
 
     return createIndex( row, 0, info );
 }
+
+void RepoInfoModel::invalidate( RepositoryInfo *info )
+{
+    if ( !info ) return;
+
+    QModelIndex index = info2Index( info );
+    emit dataChanged( index, index );
+}

--- a/Repository/RepoInfoModel.cpp
+++ b/Repository/RepoInfoModel.cpp
@@ -23,10 +23,10 @@ RepoInfoModel::RepoInfoModel()
 {
     mRepoMan = &MacGitver::repoMan();
 
-    connect( mRepoMan, SIGNAL( repositoryDeactivated(RepositoryInfo*) )
-            , this, SLOT( invalidateRepository(RepositoryInfo*) ) );
-    connect( mRepoMan, SIGNAL( repositoryActivated(RepositoryInfo*) )
-             , this, SLOT( invalidateRepository(RepositoryInfo*) ) );
+    connect( mRepoMan, SIGNAL(repositoryDeactivated(RepositoryInfo*))
+             , this, SLOT(invalidateRepository(RepositoryInfo*)) );
+    connect( mRepoMan, SIGNAL(repositoryActivated(RepositoryInfo*))
+             , this, SLOT(invalidateRepository(RepositoryInfo*)) );
 }
 
 int RepoInfoModel::rowCount( const QModelIndex& parent ) const

--- a/Repository/RepoInfoModel.cpp
+++ b/Repository/RepoInfoModel.cpp
@@ -24,9 +24,9 @@ RepoInfoModel::RepoInfoModel()
     mRepoMan = &MacGitver::repoMan();
 
     connect( mRepoMan, SIGNAL( repositoryDeactivated(RepositoryInfo*) )
-            , this, SLOT( invalidate(RepositoryInfo*) ) );
+            , this, SLOT( invalidateRepository(RepositoryInfo*) ) );
     connect( mRepoMan, SIGNAL( repositoryActivated(RepositoryInfo*) )
-             , this, SLOT( invalidate(RepositoryInfo*) ) );
+             , this, SLOT( invalidateRepository(RepositoryInfo*) ) );
 }
 
 int RepoInfoModel::rowCount( const QModelIndex& parent ) const
@@ -151,7 +151,7 @@ QModelIndex RepoInfoModel::info2Index( RepositoryInfo* info ) const
     return createIndex( row, 0, info );
 }
 
-void RepoInfoModel::invalidate( RepositoryInfo *info )
+void RepoInfoModel::invalidateRepository( RepositoryInfo *info )
 {
     if ( !info ) return;
 

--- a/Repository/RepoInfoModel.cpp
+++ b/Repository/RepoInfoModel.cpp
@@ -44,27 +44,31 @@ int RepoInfoModel::columnCount( const QModelIndex& parent ) const
 
 QVariant RepoInfoModel::data( const QModelIndex& index, int role ) const
 {
-    if( index.isValid() )
+    if( !index.isValid() ) return QVariant();
+
+    RepositoryInfo* info = index2Info( index );
+    if( info )
     {
-        RepositoryInfo* info = index2Info( index );
-        if( info )
+        if( role == Qt::DisplayRole )
         {
-            if( role == Qt::DisplayRole )
-            {
-                return info->displayAlias();
-            }
-            else if( role == IsActive )
-            {
-                return info->isActive();
-            }
-            else if( role == Qt::FontRole )
-            {
-                QFont f1, f2;
-                f2.setBold( true );
-                return info->isActive() ? f2 : f1;
-            }
+            return info->displayAlias();
+        }
+        else if( role == IsActive )
+        {
+            return info->isActive();
+        }
+        else if( role == Qt::FontRole )
+        {
+            QFont f1, f2;
+            f2.setBold( true );
+            return info->isActive() ? f2 : f1;
+        }
+        else if ( role == Qt::ToolTipRole )
+        {
+            return trUtf8( "Branch: %1" ).arg( info->branchDisplay() );
         }
     }
+
     return QVariant();
 }
 

--- a/Repository/RepoInfoModel.cpp
+++ b/Repository/RepoInfoModel.cpp
@@ -22,6 +22,11 @@
 RepoInfoModel::RepoInfoModel()
 {
     mRepoMan = &MacGitver::repoMan();
+
+    connect( mRepoMan, SIGNAL( repositoryDeactivated(RepositoryInfo*) )
+            , this, SLOT( invalidate(RepositoryInfo*) ) );
+    connect( mRepoMan, SIGNAL( repositoryActivated(RepositoryInfo*) )
+             , this, SLOT( invalidate(RepositoryInfo*) ) );
 }
 
 int RepoInfoModel::rowCount( const QModelIndex& parent ) const

--- a/Repository/RepoInfoModel.hpp
+++ b/Repository/RepoInfoModel.hpp
@@ -44,6 +44,7 @@ public:
     RepositoryInfo* index2Info( const QModelIndex& index ) const;
     QModelIndex info2Index( RepositoryInfo* info ) const;
 
+public slots:
     void invalidate( RepositoryInfo* info );
 
 private:

--- a/Repository/RepoInfoModel.hpp
+++ b/Repository/RepoInfoModel.hpp
@@ -45,7 +45,7 @@ public:
     QModelIndex info2Index( RepositoryInfo* info ) const;
 
 public slots:
-    void invalidate( RepositoryInfo* info );
+    void invalidateRepository( RepositoryInfo* info );
 
 private:
     RepoManager*        mRepoMan;

--- a/Repository/RepoInfoModel.hpp
+++ b/Repository/RepoInfoModel.hpp
@@ -44,6 +44,8 @@ public:
     RepositoryInfo* index2Info( const QModelIndex& index ) const;
     QModelIndex info2Index( RepositoryInfo* info ) const;
 
+    void invalidate( RepositoryInfo* info );
+
 private:
     RepoManager*        mRepoMan;
 };

--- a/Repository/RepoTreeView.cpp
+++ b/Repository/RepoTreeView.cpp
@@ -82,13 +82,7 @@ void RepoTreeView::onCtxActivate()
         RepositoryInfo* info = qobject_cast< RepositoryInfo* >( action->activatedBy() );
         if( info )
         {
-            RepositoryInfo* prev = MacGitver::repoMan().activeRepository();
             MacGitver::repoMan().activate( info );
-            if ( prev != info )
-            {
-                // update previous item
-                mModel->invalidate( prev );
-            }
         }
     }
 }

--- a/Repository/RepoTreeView.cpp
+++ b/Repository/RepoTreeView.cpp
@@ -87,8 +87,7 @@ void RepoTreeView::onCtxActivate()
             if ( prev != info )
             {
                 // update previous item
-                const QModelIndex prevIndex = mModel->info2Index( prev );
-                mRepos->dataChanged( prevIndex, prevIndex );
+                mModel->invalidate( prev );
             }
         }
     }

--- a/Repository/RepoTreeView.cpp
+++ b/Repository/RepoTreeView.cpp
@@ -82,7 +82,14 @@ void RepoTreeView::onCtxActivate()
         RepositoryInfo* info = qobject_cast< RepositoryInfo* >( action->activatedBy() );
         if( info )
         {
+            RepositoryInfo* prev = MacGitver::repoMan().activeRepository();
             MacGitver::repoMan().activate( info );
+            if ( prev != info )
+            {
+                // update previous item
+                const QModelIndex prevIndex = mModel->info2Index( prev );
+                mRepos->dataChanged( prevIndex, prevIndex );
+            }
         }
     }
 }


### PR DESCRIPTION
- [x] OBSOLETE: (realized in RepoMan) - Update affected tree items when switching repositories.
- [x] idea: Display the current branch of repositories in brackets after repository name. Alternatively, this could be shown in tooltips by hovering over an item.
- [x] DEFERRED: For submodules show something similar to "git describe --tags".
