### PR TITLE
Repository tree adjustments to new RM

### DIFF
--- a/Repository/RepoTreeView.cpp
+++ b/Repository/RepoTreeView.cpp
@@ -105,7 +105,15 @@ void RepoTreeView::onCtxActivate()
 
 void RepoTreeView::onCtxClose()
 {
-
+    Heaven::Action* action = qobject_cast< Heaven::Action* >( sender() );
+    if( action )
+    {
+        RM::Repo* info = qobject_cast< RM::Repo* >( action->activatedBy() );
+        if( info )
+        {
+            info->close();
+        }
+    }
 }
 
 void RepoTreeView::onRepoActivated(RM::Repo* repo)


### PR DESCRIPTION
Adding new features based on the new, rewritten repo manager. This should contain some refactoring as well Maybe not only the repo tree, but also dependent views.
- [x] added the close action: when a repository is closed, apparently some artifacts remain in memory from other models (e.g. history). These need to know still about the closed repo. Also MGV crashes here occasionally - might be the repo pointer given on destruction.
