### PR TITLE
Working Tree: Restore filter behavior from before using ProxyFilters

### DIFF
--- a/WorkingTree/WorkingTreeDirItem.cpp
+++ b/WorkingTree/WorkingTreeDirItem.cpp
@@ -58,6 +58,9 @@ QVariant WorkingTreeDirItem::data( int column, int role ) const
         }
         break;
 
+    case StatusRole:
+        return 0;
+
     default:
         break;
     }


### PR DESCRIPTION
A thing that bothered me for quiete a while now: When I filter away unchanged entries in the WT, all directories are still shown.

This is regression was introduced with the moving to the proxy model for filtering. The actual cause is that we don't recursively check if the filter rules apply to all children. But this was hidden by a "workaround" bugfix (DirItems didn't report status, so they were just always accepted).

This commit fixes both issues and restores the behaviour before the change to the filter proxy...
