### PR TITLE
Context menu for history view

### DIFF
--- a/History/CMakeLists.txt
+++ b/History/CMakeLists.txt
@@ -46,6 +46,7 @@ SET(UI_FILES
 SET(HID_FILES
 
     HistoryViewActions.hid
+    HistoryCtxMenu.hid
 )
 
 SET(RCC_FILES

--- a/History/CMakeLists.txt
+++ b/History/CMakeLists.txt
@@ -10,6 +10,8 @@ INCLUDE_DIRECTORIES(
 
 SET(SRC_FILES
 
+    CreateBranchDialog.cpp
+
     HistoryView.cpp
     HistoryListDelegate.cpp
     HistoryList.cpp
@@ -25,6 +27,8 @@ SET(SRC_FILES
 
 SET(HDR_FILES
 
+    CreateBranchDialog.h
+
     HistoryView.h
     HistoryListDelegate.h
     HistoryList.h
@@ -39,6 +43,8 @@ SET(HDR_FILES
 )
 
 SET(UI_FILES
+
+    CreateBranchDialog.ui
 
     HistoryConfigPage.ui
 )

--- a/History/CMakeLists.txt
+++ b/History/CMakeLists.txt
@@ -11,6 +11,7 @@ INCLUDE_DIRECTORIES(
 SET(SRC_FILES
 
     CreateBranchDialog.cpp
+    CreateTagDialog.cpp
 
     HistoryView.cpp
     HistoryListDelegate.cpp
@@ -28,6 +29,7 @@ SET(SRC_FILES
 SET(HDR_FILES
 
     CreateBranchDialog.h
+    CreateTagDialog.h
 
     HistoryView.h
     HistoryListDelegate.h
@@ -45,6 +47,7 @@ SET(HDR_FILES
 SET(UI_FILES
 
     CreateBranchDialog.ui
+    CreateTagDialog.ui
 
     HistoryConfigPage.ui
 )

--- a/History/CreateBranchDialog.cpp
+++ b/History/CreateBranchDialog.cpp
@@ -1,0 +1,24 @@
+#include "CreateBranchDialog.h"
+#include "ui_CreateBranchDialog.h"
+
+CreateBranchDialog::CreateBranchDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::CreateBranchDialog)
+{
+    ui->setupUi(this);
+}
+
+CreateBranchDialog::~CreateBranchDialog()
+{
+    delete ui;
+}
+
+QString CreateBranchDialog::branchName() const
+{
+    return ui->textBranchName->text();
+}
+
+bool CreateBranchDialog::checkoutBranch() const
+{
+    return ui->btnCheckoutBranch->isChecked();
+}

--- a/History/CreateBranchDialog.h
+++ b/History/CreateBranchDialog.h
@@ -1,0 +1,26 @@
+#ifndef CREATEBRANCHDIALOG_H
+#define CREATEBRANCHDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+    class CreateBranchDialog;
+}
+
+class CreateBranchDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CreateBranchDialog(QWidget *parent = 0);
+    ~CreateBranchDialog();
+
+    QString branchName() const;
+
+    bool checkoutBranch() const;
+
+private:
+    Ui::CreateBranchDialog *ui;
+};
+
+#endif // CREATEBRANCHDIALOG_H

--- a/History/CreateBranchDialog.ui
+++ b/History/CreateBranchDialog.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateBranchDialog</class>
+ <widget class="QDialog" name="CreateBranchDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>405</width>
+    <height>108</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Branch name:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="textBranchName"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="btnCheckoutBranch">
+     <property name="text">
+      <string>Checkout branch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Abort|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>CreateBranchDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>CreateBranchDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/History/CreateTagDialog.cpp
+++ b/History/CreateTagDialog.cpp
@@ -1,0 +1,19 @@
+#include "CreateTagDialog.h"
+#include "ui_CreateTagDialog.h"
+
+CreateTagDialog::CreateTagDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::CreateTagDialog)
+{
+    ui->setupUi(this);
+}
+
+CreateTagDialog::~CreateTagDialog()
+{
+    delete ui;
+}
+
+QString CreateTagDialog::tagName() const
+{
+    return ui->textTagName->text();
+}

--- a/History/CreateTagDialog.h
+++ b/History/CreateTagDialog.h
@@ -1,0 +1,24 @@
+#ifndef CREATETAGDIALOG_H
+#define CREATETAGDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+    class CreateTagDialog;
+}
+
+class CreateTagDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CreateTagDialog(QWidget *parent = 0);
+    ~CreateTagDialog();
+
+    QString tagName() const;
+
+private:
+    Ui::CreateTagDialog *ui;
+};
+
+#endif // CREATETAGDIALOG_H

--- a/History/CreateTagDialog.ui
+++ b/History/CreateTagDialog.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateTagDialog</class>
+ <widget class="QDialog" name="CreateTagDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>85</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Tag name:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="textTagName"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>CreateTagDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>CreateTagDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/History/HistoryCtxMenu.hid
+++ b/History/HistoryCtxMenu.hid
@@ -30,11 +30,19 @@ Ui HistoryTreeCtxMenu {
         ConnectTo       onCreateBranch();
     };
 
+    Action CreateTag {
+        Text            "Create &Tag";
+        StatusToolTip   "Create a tag on this commit.";
+        ConnectTo       onCreateTag();
+    };
+
     Menu CtxMenuHistory {
 
         Action      Checkout;
         Separator;
         Action      CreateBranch;
+        Separator;
+        Action      CreateTag;
 
     };
 

--- a/History/HistoryCtxMenu.hid
+++ b/History/HistoryCtxMenu.hid
@@ -1,0 +1,41 @@
+/*
+ * libGitWrap - A Qt wrapper library for libgit2
+ * Copyright (C) 2013-2014 The MacGitver-Developers <dev@macgitver.org>
+ *
+ * (C) Nils Fenner <nilsfenner@web.de>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+Ui HistoryTreeCtxMenu {
+
+    Action Checkout {
+        Text            "Checkout";
+        StatusToolTip   "Checkout this commit.";
+        ConnectTo       onCheckout();
+    };
+
+    Action CreateBranch {
+        Text            "Create &Branch";
+        StatusToolTip   "Create a branch on this commit.";
+        ConnectTo       onCreateBranch();
+    };
+
+    Menu CtxMenuHistory {
+
+        Action      Checkout;
+        Separator;
+        Action      CreateBranch;
+
+    };
+
+};

--- a/History/HistoryList.cpp
+++ b/History/HistoryList.cpp
@@ -20,6 +20,7 @@
 #include "HistoryModel.h"
 #include "HistoryEntry.h"
 
+#include <QAbstractProxyModel>
 HistoryList::HistoryList( QWidget* parent )
     : TreeViewCtxMenu( parent )
     , ConfigUser( "History" )
@@ -94,4 +95,18 @@ void HistoryList::contextMenu( const QModelIndex& index, const QPoint& globalPos
 
     if ( menu )
         menu->showPopup( globalPos );
+}
+
+QModelIndex HistoryList::deeplyMapToSource( QModelIndex current ) const
+{
+    while( current.isValid() )
+    {
+        const QAbstractProxyModel* apm = qobject_cast< const QAbstractProxyModel* >( current.model() );
+        if( !apm )
+            return current;
+
+        current = apm->mapToSource( current );
+    }
+
+    return QModelIndex();
 }

--- a/History/HistoryList.cpp
+++ b/History/HistoryList.cpp
@@ -20,6 +20,7 @@
 #include "libMacGitverCore/Widgets/HeaderView.h"
 
 #include "CreateBranchDialog.h"
+#include "CreateTagDialog.h"
 #include "HistoryList.h"
 #include "HistoryModel.h"
 #include "HistoryEntry.h"
@@ -201,5 +202,46 @@ void HistoryList::onCreateBranch()
     if ( dlg->checkoutBranch() )
     {
         checkoutBranch( branch );
+    }
+}
+
+
+
+void HistoryList::onCreateTag()
+{
+    QMessageBox::information( this, trUtf8("Tag was not created"),
+                              trUtf8("Creating tags is not available yet.") );
+
+    return;
+
+    Heaven::Action* action = qobject_cast< Heaven::Action* >( sender() );
+    if ( !action )
+        return;
+
+    QModelIndex srcIndex = deeplyMapToSource( currentIndex() );
+    if ( !srcIndex.isValid() )
+        return;
+
+    HistoryEntry* item = mModel->indexToEntry( srcIndex );
+    Q_ASSERT( item );
+
+    Git::Result r;
+
+    RM::Repo *repo = MacGitver::repoMan().activeRepository();
+    Q_ASSERT( repo );
+
+    CreateTagDialog *dlg = new CreateTagDialog(this);
+    if ( dlg->exec() != QDialog::Accepted )
+        return;
+
+    Git::Repository gitRepo = repo->gitRepo();
+    // TODO: implementation of createTag() in libgGitWrap
+//    Git::Tag tag = gitRepo.lookupCommit( r, item->id() ).createTag( r, dlg->tagName() );
+
+    if ( !r )
+    {
+        QMessageBox::information( this, trUtf8("Failed to create tag"),
+                                  trUtf8("Failed to create tag. Git message:\n%1").arg(r.errorText()) );
+        return;
     }
 }

--- a/History/HistoryList.cpp
+++ b/History/HistoryList.cpp
@@ -14,8 +14,6 @@
  *
  */
 
-#include <QDebug>
-
 #include "libMacGitverCore/Widgets/HeaderView.h"
 
 #include "HistoryList.h"

--- a/History/HistoryList.h
+++ b/History/HistoryList.h
@@ -47,6 +47,9 @@ private slots:
     void onCurrentChanged();
     void contextMenu(const QModelIndex& index, const QPoint& globalPos);
 
+    void onCheckout();
+    void onCreateBranch();
+
 private:
     HistoryModel *      mModel;
 };

--- a/History/HistoryList.h
+++ b/History/HistoryList.h
@@ -49,6 +49,7 @@ private slots:
 
     void onCheckout();
     void onCreateBranch();
+    void onCreateTag();
 
 private:
     HistoryModel *      mModel;

--- a/History/HistoryList.h
+++ b/History/HistoryList.h
@@ -52,6 +52,9 @@ private slots:
 
 private:
     HistoryModel *      mModel;
+
+private:
+    inline void checkoutBranch(Git::Reference branch);
 };
 
 #endif

--- a/History/HistoryList.h
+++ b/History/HistoryList.h
@@ -20,14 +20,17 @@
 #include "libMacGitverCore/Config/ConfigUser.h"
 
 #include "libGitWrap/ObjectId.hpp"
+#include "libMacGitverCore/Widgets/TreeViewCtxMenu.hpp"
 
-#include <QTreeView>
+#include "hic_HistoryCtxMenu.h"
 
-class HistoryList : public QTreeView, private ConfigUser
+class HistoryModel;
+
+class HistoryList : public TreeViewCtxMenu, private HistoryTreeCtxMenu, private ConfigUser
 {
     Q_OBJECT
 public:
-    HistoryList();
+    HistoryList( QWidget* parent = 0 );
 
 public:
     void setModel( QAbstractItemModel* model );
@@ -40,6 +43,10 @@ private:
 
 private slots:
     void onCurrentChanged();
+    void contextMenu(const QModelIndex& index, const QPoint& globalPos);
+
+private:
+    HistoryModel *      mModel;
 };
 
 #endif

--- a/History/HistoryList.h
+++ b/History/HistoryList.h
@@ -41,6 +41,8 @@ signals:
 private:
     void configChanged( const QString& subPath, const QVariant& value );
 
+    QModelIndex deeplyMapToSource( QModelIndex current ) const;
+
 private slots:
     void onCurrentChanged();
     void contextMenu(const QModelIndex& index, const QPoint& globalPos);


### PR DESCRIPTION
Let's add some action to the context menu, giving it abilities to interact with the history.
- [x] add context menu

Give it an "easy start" by adding cool `libGitWrap` stuff, that is almost ready to use and just needs some finalization there.

So here comes the first actions:
- [x] checkout a commit in history
  If a local branch is pointing here, we should ask the user, if he wants to checkout and activate it. We could also create a new branch, but this workflow is provided by the following action either.
- [x] create a (local) branch on a selected history item
  Later, we could think of creating remote branches as well, but that is pretty advanced stuff. In the first run we leave that out and keep the workflow simple.
