### PR TITLE
coloring ref. labels within history

### DIFF
--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -290,8 +290,6 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
             p->setFont( opt.font );
 
             QRect refRect( r.left(), r.top() + 1, w, r.height() - 3 );
-            QPainterPath refPath;
-            refPath.addRoundRect( refRect, 20 );
 
             QColor back = QColor( 0xD9D9D9 );
             if( ref.mIsTag )
@@ -308,13 +306,16 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
                     back = QColor( 0x9BFD51 );
             }
 
-            p->fillPath( refPath, back );
-            QPen blackPen(Qt::black);
-            blackPen.setWidth(0);
-            p->setPen(blackPen);
-            p->drawPath( refPath );
+            QLinearGradient gradient( refRect.left(), 0, refRect.right(), 0 );
+            gradient.setColorAt( 0.0, back.lighter(125) );
+            gradient.setColorAt( 0.33, back );
+
+            p->setBrush( gradient );
+            p->setPen( QPen(Qt::transparent) );
+            p->drawRoundedRect( refRect, 2.5, 2.5 );
 
             refRect.adjust( 2, 0, -2, 0 );
+            p->setPen( QPen(Qt::black) );
             p->drawText( refRect, Qt::AlignCenter, ref.mRefName );
 
             r.setLeft( r.left() + w + 3 );

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -293,7 +293,7 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
             QPainterPath refPath;
             refPath.addRoundRect( refRect, 20 );
 
-            QColor back = Qt::white;
+            QColor back = QColor( 0xD9D9D9 );
             if( ref.mIsTag )
             {
                 back = Qt::yellow;
@@ -305,7 +305,7 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
                 else if ( ref.mIsCurrent )
                     back = QColor( 0xFFB54F );
                 else
-                    back = QColor( Qt::green );
+                    back = QColor( 0x9BFD51 );
             }
 
             p->fillPath( refPath, back );

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -301,6 +301,8 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
             }
 
             QRect refRect( r.left(), r.top() + 1, w, r.height() - 3 );
+            QPainterPath refPath;
+            refPath.addRoundRect( refRect, 20 );
 
             QColor back = Qt::white;
             if( ref.mIsTag )
@@ -317,11 +319,11 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
                     back = QColor( Qt::green );
             }
 
-            p->fillRect( refRect, back );
+            p->fillPath( refPath, back );
             QPen blackPen(Qt::black);
             blackPen.setWidth(0);
             p->setPen(blackPen);
-            p->drawRect( refRect );
+            p->drawPath( refPath );
 
             refRect.adjust( 2, 0, -2, 0 );
             p->drawText( refRect, Qt::AlignCenter, ref.mRefName );

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -315,7 +315,7 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
 
     if( !e )
     {
-        // If we're still required to populate that entry, don't do anyhting here
+        // If we're still required to populate that entry, don't do anything here
         return;
     }
 

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -264,19 +264,19 @@ QColor HistoryListDelegate::laneColor(int lane)
     static const QColor laneColors[] =
     {
         QColor::fromHsl( 200, 255, 128 ), // blue
-        QColor::fromHsl( 280, 255, 128 ), // violett
+        QColor::fromHsl( 280, 255, 128 ), // purple
         QColor::fromHsl(   8, 255, 128 ), // red
         QColor::fromHsl(  56, 255, 128 ), // yellow
         QColor::fromHsl( 133, 255, 128 ), // green
 
-        QColor::fromHsl(  93, 255, 128 ), // green
+        QColor::fromHsl(   0,  10, 128 ), // gray
         QColor::fromHsl(  30, 255, 128 ), // orange
         QColor::fromHsl(  44, 255, 128 ), // yellow
         QColor::fromHsl( 226, 255, 128 ), // blue
         QColor::fromHsl(  69, 255, 128 ), // yellow-green
 
-        QColor::fromHsl( 273, 255, 128 ), // violett
-        QColor::fromHsl( 135, 255, 128 )  // green
+        QColor::fromHsl(   0,  10, 230 ), // light-gray
+        QColor::fromHsl( 135, 255, 230 )  // light-green
     };
 
     return laneColors[lane % 12];

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -170,7 +170,7 @@ void HistoryListDelegate::paintGraphLane( QPainter* p, GraphGlyphs glyph, GraphG
         break;
     }
 
-    QPen blackPen(Qt::black);
+    QPen blackPen(col.darker());
     blackPen.setWidth(0);
     p->setPen(blackPen);
     // center symbol, e.g. rect or ellipse
@@ -210,11 +210,6 @@ void HistoryListDelegate::paintGraphLane( QPainter* p, GraphGlyphs glyph, GraphG
 void HistoryListDelegate::paintGraph( QPainter* p, const QStyleOptionViewItem& opt,
                                       const QModelIndex& i ) const
 {
-    static const QColor colors[] = { Qt::red, //DARK_GREEN,
-                                               Qt::blue, Qt::darkGray, //BROWN,
-                                               Qt::magenta //, ORANGE
-                                             };
-
     const HistoryModel* m = qobject_cast< const HistoryModel* >( i.model() );
     HistoryEntry* e = m->at( i.row() );
 
@@ -245,7 +240,7 @@ void HistoryListDelegate::paintGraph( QPainter* p, const QStyleOptionViewItem& o
     int height = opt.rect.height();
     int maxWidth = opt.rect.width();
     int lw = 3 * 18 / 4;
-    QColor activeColor = colors[activeLane % 4];
+    QColor activeColor = laneColor( activeLane );
 //	if (opt.state & QStyle::State_Selected)
 //		activeColor = blend(activeColor, opt.palette.highlightedText().color(), 208);
     for (uint i = 0; i < laneNum && x2 < maxWidth; i++) {
@@ -256,12 +251,35 @@ void HistoryListDelegate::paintGraph( QPainter* p, const QStyleOptionViewItem& o
         GraphGlyphs ln = lanes[i];
         if( ln != ggUnused )
         {
-            QColor color = i == activeLane ? activeColor : colors[i % 4];
+            QColor color = i == activeLane ? activeColor : laneColor( i );
             GraphGlyphs nextGlyph = ( i < laneNum - 1 ) ? lanes[ i + 1 ] : ggUnused;
             paintGraphLane(p, ln, nextGlyph, x1, x2, height, color, activeColor, back);
         }
     }
     p->restore();
+}
+
+QColor HistoryListDelegate::laneColor(int lane)
+{
+    static const QColor laneColors[] =
+    {
+        QColor::fromHsl( 200, 255, 128 ), // blue
+        QColor::fromHsl( 280, 255, 128 ), // violett
+        QColor::fromHsl(   8, 255, 128 ), // red
+        QColor::fromHsl(  56, 255, 128 ), // yellow
+        QColor::fromHsl( 133, 255, 128 ), // green
+
+        QColor::fromHsl(  93, 255, 128 ), // green
+        QColor::fromHsl(  30, 255, 128 ), // orange
+        QColor::fromHsl(  44, 255, 128 ), // yellow
+        QColor::fromHsl( 226, 255, 128 ), // blue
+        QColor::fromHsl(  69, 255, 128 ), // yellow-green
+
+        QColor::fromHsl( 273, 255, 128 ), // violett
+        QColor::fromHsl( 135, 255, 128 )  // green
+    };
+
+    return laneColors[lane % 12];
 }
 
 void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem& opt,

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -349,10 +349,13 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
                     back = QColor( 0x9BFD51 );
             }
 
+            QColor back2 = back.lighter(135);
             const qreal wLimit = qreal( qMin(30, refRect.width()) ) / qreal( qMax(30, refRect.width()) );
             QLinearGradient gradient( refRect.left(), 0, refRect.right(), 0 );
-            gradient.setColorAt( 0.0, back.lighter(125) );
+            gradient.setColorAt( 0.0, back2 );
             gradient.setColorAt( wLimit, back );
+            gradient.setColorAt( 1.0 - wLimit, back );
+            gradient.setColorAt( 1.0, back2 );
 
             p->setBrush( gradient );
             p->setPen( QPen(Qt::transparent) );

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -286,19 +286,8 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
         for( int refIdx = 0; refIdx < refs.count(); refIdx++ )
         {
             const HistoryInlineRef& ref = refs.at( refIdx );
-            int w;
-            if( ref.mIsCurrent )
-            {
-                QFont f = opt.font;
-                f.setBold( true );
-                w = QFontMetrics( f ).width( ref.mRefName ) + 6;
-                p->setFont( f );
-            }
-            else
-            {
-                w = opt.fontMetrics.width( ref.mRefName ) + 6;
-                p->setFont( opt.font );
-            }
+            int w = opt.fontMetrics.width( ref.mRefName ) + 6;
+            p->setFont( opt.font );
 
             QRect refRect( r.left(), r.top() + 1, w, r.height() - 3 );
             QPainterPath refPath;

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -19,6 +19,35 @@
 #include "HistoryModel.h"
 #include "HistoryListDelegate.h"
 
+
+namespace Internal
+{
+    const QColor laneColors[] =
+    {
+        QColor::fromHsl( 200, 255, 128 ), // blue
+        QColor::fromHsl( 280, 255, 128 ), // purple
+        QColor::fromHsl(   8, 255, 128 ), // red
+        QColor::fromHsl(  56, 255, 128 ), // yellow
+        QColor::fromHsl( 133, 255, 128 ), // green
+
+        QColor::fromHsl(   0,  10, 128 ), // gray
+        QColor::fromHsl(  30, 255, 128 ), // orange
+        QColor::fromHsl(  44, 255, 128 ), // yellow
+        QColor::fromHsl( 226, 255, 128 ), // blue
+        QColor::fromHsl(  69, 255, 128 ), // yellow-green
+
+        QColor::fromHsl(   0,  10, 230 ), // light-gray
+        QColor::fromHsl( 135, 255, 230 )  // light-green
+    };
+
+    inline QColor laneColor(int lane)
+    {
+        return laneColors[lane % 12];
+    }
+
+}
+
+
 void HistoryListDelegate::paintGraphLane( QPainter* p, GraphGlyphs glyph, GraphGlyphs lastGlyph,
                                           int x1, int x2, int height, const QColor& col,
                                           const QColor& activeCol, const QBrush& back ) const
@@ -240,7 +269,7 @@ void HistoryListDelegate::paintGraph( QPainter* p, const QStyleOptionViewItem& o
     int height = opt.rect.height();
     int maxWidth = opt.rect.width();
     int lw = 3 * 18 / 4;
-    QColor activeColor = laneColor( activeLane );
+    QColor activeColor = Internal::laneColor( activeLane );
 //	if (opt.state & QStyle::State_Selected)
 //		activeColor = blend(activeColor, opt.palette.highlightedText().color(), 208);
     for (uint i = 0; i < laneNum && x2 < maxWidth; i++) {
@@ -251,35 +280,12 @@ void HistoryListDelegate::paintGraph( QPainter* p, const QStyleOptionViewItem& o
         GraphGlyphs ln = lanes[i];
         if( ln != ggUnused )
         {
-            QColor color = i == activeLane ? activeColor : laneColor( i );
+            QColor color = i == activeLane ? activeColor : Internal::laneColor( i );
             GraphGlyphs nextGlyph = ( i < laneNum - 1 ) ? lanes[ i + 1 ] : ggUnused;
             paintGraphLane(p, ln, nextGlyph, x1, x2, height, color, activeColor, back);
         }
     }
     p->restore();
-}
-
-QColor HistoryListDelegate::laneColor(int lane)
-{
-    static const QColor laneColors[] =
-    {
-        QColor::fromHsl( 200, 255, 128 ), // blue
-        QColor::fromHsl( 280, 255, 128 ), // purple
-        QColor::fromHsl(   8, 255, 128 ), // red
-        QColor::fromHsl(  56, 255, 128 ), // yellow
-        QColor::fromHsl( 133, 255, 128 ), // green
-
-        QColor::fromHsl(   0,  10, 128 ), // gray
-        QColor::fromHsl(  30, 255, 128 ), // orange
-        QColor::fromHsl(  44, 255, 128 ), // yellow
-        QColor::fromHsl( 226, 255, 128 ), // blue
-        QColor::fromHsl(  69, 255, 128 ), // yellow-green
-
-        QColor::fromHsl(   0,  10, 230 ), // light-gray
-        QColor::fromHsl( 135, 255, 230 )  // light-green
-    };
-
-    return laneColors[lane % 12];
 }
 
 void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem& opt,

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -324,9 +324,10 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
                     back = QColor( 0x9BFD51 );
             }
 
+            const qreal wLimit = qreal( qMin(30, refRect.width()) ) / qreal( qMax(30, refRect.width()) );
             QLinearGradient gradient( refRect.left(), 0, refRect.right(), 0 );
             gradient.setColorAt( 0.0, back.lighter(125) );
-            gradient.setColorAt( 0.33, back );
+            gradient.setColorAt( wLimit, back );
 
             p->setBrush( gradient );
             p->setPen( QPen(Qt::transparent) );

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -319,12 +319,15 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
 
             r.setLeft( r.left() + w + 3 );
         }
-        r.setLeft( r.left() + 3 );
     }
 
-    p->drawText( r, Qt::AlignTop | Qt::AlignLeft, i.data().toString() );
-
     p->restore();
+
+    // draw text in original color
+    QStyleOptionViewItem newOpt(opt);
+    newOpt.rect = r;
+    newOpt.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
+    QItemDelegate::paint( p, newOpt, i );
 }
 
 void HistoryListDelegate::paint( QPainter* painter, const QStyleOptionViewItem& option,

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -288,6 +288,25 @@ void HistoryListDelegate::paintGraph( QPainter* p, const QStyleOptionViewItem& o
     p->restore();
 }
 
+QColor HistoryListDelegate::colorForRefType(const HistoryInlineRef& ref) const
+{
+    if( ref.mIsTag )
+        return Qt::yellow;
+
+    if( ref.mIsBranch )
+    {
+        if ( ref.mIsRemote )
+            return QColor::fromHsl(203, 255, 190);
+
+        if ( ref.mIsCurrent )
+            return QColor::fromHsl(35, 255, 190);
+
+        return QColor::fromHsl(89, 255, 190);
+    }
+
+    return QColor( 0xD9D9D9 );
+}
+
 void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem& opt,
                                         const QModelIndex& i ) const
 {

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -309,7 +309,12 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
             }
             else if( ref.mIsBranch )
             {
-                back = ref.mIsRemote ? Qt::green : Qt::darkGreen;
+                if ( ref.mIsRemote )
+                    back = QColor( 0xB8E4FF );
+                else if ( ref.mIsCurrent )
+                    back = QColor( 0xFFB54F );
+                else
+                    back = QColor( Qt::green );
             }
 
             p->fillRect( refRect, back );

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -334,21 +334,7 @@ void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem&
 
             QRect refRect( r.left(), r.top() + 1, w, r.height() - 3 );
 
-            QColor back = QColor( 0xD9D9D9 );
-            if( ref.mIsTag )
-            {
-                back = Qt::yellow;
-            }
-            else if( ref.mIsBranch )
-            {
-                if ( ref.mIsRemote )
-                    back = QColor( 0xB8E4FF );
-                else if ( ref.mIsCurrent )
-                    back = QColor( 0xFFB54F );
-                else
-                    back = QColor( 0x9BFD51 );
-            }
-
+            QColor back = colorForRefType(ref);
             QColor back2 = back.lighter(135);
             const qreal wLimit = qreal( qMin(30, refRect.width()) ) / qreal( qMax(30, refRect.width()) );
             QLinearGradient gradient( refRect.left(), 0, refRect.right(), 0 );

--- a/History/HistoryListDelegate.h
+++ b/History/HistoryListDelegate.h
@@ -39,8 +39,6 @@ private:
     void paintGraph( QPainter* p, const QStyleOptionViewItem& opt,
                      const QModelIndex& i ) const;
 
-    inline static QColor laneColor( int lane );
-
     void paintMessage( QPainter* p, const QStyleOptionViewItem& opt,
                        const QModelIndex& i ) const;
 };

--- a/History/HistoryListDelegate.h
+++ b/History/HistoryListDelegate.h
@@ -41,6 +41,7 @@ private:
 
     void paintMessage( QPainter* p, const QStyleOptionViewItem& opt,
                        const QModelIndex& i ) const;
+    inline QColor colorForRefType(const HistoryInlineRef& ref) const;
 };
 
 #endif

--- a/History/HistoryListDelegate.h
+++ b/History/HistoryListDelegate.h
@@ -39,6 +39,8 @@ private:
     void paintGraph( QPainter* p, const QStyleOptionViewItem& opt,
                      const QModelIndex& i ) const;
 
+    inline static QColor laneColor( int lane );
+
     void paintMessage( QPainter* p, const QStyleOptionViewItem& opt,
                        const QModelIndex& i ) const;
 };

--- a/History/HistoryView.cpp
+++ b/History/HistoryView.cpp
@@ -54,9 +54,6 @@ HistoryView::HistoryView()
     setViewName( trUtf8( "History" ) );
     setToolBar( tbHistoryViewToolBar );
 
-    setSizePolicy( QSizePolicy::MinimumExpanding,
-                   QSizePolicy::MinimumExpanding );
-
     mList = new HistoryList;
     mList->setFrameShape( QFrame::NoFrame );
 

--- a/History/HistoryView.cpp
+++ b/History/HistoryView.cpp
@@ -44,6 +44,8 @@
 HistoryView::HistoryView()
     : View( "History" )
     , ConfigUser( "History" )
+    , mModel( 0 )
+    , mRepo( 0 )
 {
     setupActions( this );
 
@@ -61,20 +63,15 @@ HistoryView::HistoryView()
     connect( mList, SIGNAL(currentCommitChanged(Git::ObjectId)),
              this, SLOT(currentCommitChanged(Git::ObjectId)) );
 
-    mDelegate = new HistoryListDelegate;
-
-    mList->setItemDelegate( mDelegate );
+    mList->setItemDelegate( new HistoryListDelegate );
 
     mDetails = new HistoryDetails;
     mDiff = new HistoryDiff;
-
-    mModel = NULL;
 
     actHistoryShowHEADonly->setChecked(true);
 
     initSplitters();
 
-    mRepo = NULL;
     connect( &MacGitver::repoMan(), SIGNAL(repositoryActivated(RM::Repo*)),
              this,                  SLOT(repoActivated(RM::Repo*)));
 

--- a/History/HistoryView.h
+++ b/History/HistoryView.h
@@ -74,7 +74,6 @@ private:
 private:
     BlueSky::MiniSplitter*  mVertSplit;
     BlueSky::MiniSplitter*  mHorzSplit;
-    HistoryListDelegate*    mDelegate;
     HistoryModel*           mModel;
     HistoryList*            mList;
     HistoryDetails*         mDetails;


### PR DESCRIPTION
This looks beatiful in my eyes :). Colors taken from GitX. The color for the current branch is the same everywhere in MGV now, which is a nice thing.

These colors could be customizable within the settings - but that's a topic for v0.2. For now let's take fixed colors and make a redmine ticket out of the issue :).

This is how it looks:
![mgv-history-colors](https://cloud.githubusercontent.com/assets/440517/2938179/ea9f650c-d8f5-11e3-929c-de3ac6ea3c20.png)

@claus007 FYI :smile:
