### PR TITLE
Reorganized clone dialog

### DIFF
--- a/History/HistoryCtxMenu.hid
+++ b/History/HistoryCtxMenu.hid
@@ -36,14 +36,20 @@ Ui HistoryTreeCtxMenu {
         ConnectTo       onCreateTag();
     };
 
+    Action ShowHEAD {
+        Text            "Show HEAD";
+        StatusToolTip   "Highlight the HEAD commit in the history.";
+        ConnectTo       onShowHEAD();
+    };
+
     Menu CtxMenuHistory {
 
         Action      Checkout;
         Separator;
         Action      CreateBranch;
-        Separator;
         Action      CreateTag;
-
+        Separator;
+        Action      ShowHEAD;
     };
 
 };

--- a/History/HistoryList.cpp
+++ b/History/HistoryList.cpp
@@ -144,12 +144,22 @@ void HistoryList::onCheckout()
     Q_ASSERT( repo );
 
     Git::Repository gitRepo = repo->gitRepo();
-    gitRepo.lookupCommit( r, item->id() ).checkout( r );
+    Git::Commit commit = gitRepo.lookupCommit( r, item->id() );
+
+    if ( r )
+    {
+        Git::CheckoutCommitOperation op( commit );
+        op.setMode( Git::CheckoutSafe );
+        op.setStrategy( Git::CheckoutUpdateHEAD | Git::CheckoutAllowConflicts | Git::CheckoutAllowDetachHEAD );
+        op.execute();
+        r = op.result();
+    }
 
     if ( !r )
     {
-        QMessageBox::information( this, trUtf8("Failed to checkout"),
-                                  trUtf8("Failed to checkout. Git message:\n%1").arg(r.errorText()));
+        QMessageBox::information( this, trUtf8("Checkout of commit failed"),
+                                  trUtf8("Checkout of commit failed. Git message:\n%1").arg(r.errorText()));
+        return;
     }
 }
 

--- a/History/HistoryList.cpp
+++ b/History/HistoryList.cpp
@@ -29,6 +29,7 @@
 #include "libGitWrap/Commit.hpp"
 #include "libGitWrap/Repository.hpp"
 #include "libGitWrap/Reference.hpp"
+#include "libGitWrap/Tag.hpp"
 
 #include "libGitWrap/Operations/CheckoutOperation.hpp"
 
@@ -223,11 +224,6 @@ void HistoryList::onCreateBranch()
 
 void HistoryList::onCreateTag()
 {
-    QMessageBox::information( this, trUtf8("Tag was not created"),
-                              trUtf8("Creating tags is not available yet.") );
-
-    return;
-
     Heaven::Action* action = qobject_cast< Heaven::Action* >( sender() );
     if ( !action )
         return;
@@ -249,8 +245,7 @@ void HistoryList::onCreateTag()
         return;
 
     Git::Repository gitRepo = repo->gitRepo();
-    // TODO: implementation of createTag() in libgGitWrap
-//    Git::Tag tag = gitRepo.lookupCommit( r, item->id() ).createTag( r, dlg->tagName() );
+    Git::Tag::createLight( r, dlg->tagName(), gitRepo.lookupCommit( r, item->id() ) );
 
     if ( !r )
     {

--- a/History/HistoryList.cpp
+++ b/History/HistoryList.cpp
@@ -254,3 +254,31 @@ void HistoryList::onCreateTag()
         return;
     }
 }
+
+void HistoryList::onShowHEAD()
+{
+    Git::Result r;
+
+    Git::Repository repo = MacGitver::repoMan().activeRepository()->gitRepo();
+    Git::ObjectId headId = repo.HEAD( r ).resolveToObjectId( r );
+
+    if ( !r ) {
+        QMessageBox::information( this, tr("Unable to lookup HEAD"),
+                                  tr("Git message:\n%1").arg( r.errorText() ) );
+        return;
+    }
+
+    QModelIndex headIndex = mModel->indexByObjectId( headId );
+    if ( headIndex.isValid() ) {
+        scrollTo( headIndex );
+        selectionModel()->select( headIndex, QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows );
+    }
+    else {
+        // TODO: Migrate the model data to RepoMan objects and .
+        QMessageBox::information( this, tr("HEAD not found!"),
+                                  tr("HEAD commit was not found in history.\n\n"
+                                     "Important Note: This is a feature preview!\n\n"
+                                     "Please make sure the HEAD commit is at least once visible!" ) );
+    }
+}
+

--- a/History/HistoryList.cpp
+++ b/History/HistoryList.cpp
@@ -158,6 +158,8 @@ void HistoryList::checkout(Git::Result& result, const Git::Reference& ref)
     GW_CHECK_RESULT( result, void() )
 
     Git::CheckoutReferenceOperation* op = new Git::CheckoutReferenceOperation( ref );
+    op->setMode( Git::CheckoutSafe );
+    op->setStrategy( Git::CheckoutUpdateHEAD | Git::CheckoutAllowConflicts );
     // TODO: op->setBackgroundMode( true );
     op->execute();
 

--- a/History/HistoryList.h
+++ b/History/HistoryList.h
@@ -55,7 +55,7 @@ private:
     HistoryModel *      mModel;
 
 private:
-    inline void checkoutBranch(Git::Result& result, const Git::Reference& branch);
+    inline void checkout(Git::Result& result, const Git::Reference& ref);
 };
 
 #endif

--- a/History/HistoryList.h
+++ b/History/HistoryList.h
@@ -51,6 +51,8 @@ private slots:
     void onCreateBranch();
     void onCreateTag();
 
+    void onShowHEAD();
+
 private:
     HistoryModel *      mModel;
 

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -83,6 +83,19 @@ int HistoryModel::columnMap( int index ) const
     return -1;
 }
 
+QModelIndex HistoryModel::indexByObjectId(const Git::ObjectId& id) const
+{
+    for ( int row=0; row <  mEntries.count(); ++row ) {
+        const HistoryEntry* e = at( row );
+
+        if ( e && (e->id() == id) ) {
+            return index( row, 0, QModelIndex() );
+        }
+    }
+
+    return QModelIndex();
+}
+
 int HistoryModel::rowCount( const QModelIndex& parent ) const
 {
     if( parent.isValid() )

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -90,7 +90,7 @@ public:
     void buildHistory();
 
 private:
-    void updateRow( int row );
+    void updateRows( int firstRow, int lastRow );
     void scanInlineReferences();
 
 public slots:

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -75,6 +75,8 @@ public:
     int columnMap( int index ) const;
 
 public:
+    QModelIndex indexByObjectId( const Git::ObjectId& id ) const;
+
     HistoryEntry* indexToEntry( const QModelIndex& index ) const;
     HistoryEntry* at( int row, bool populate = true ) const;
 

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -30,6 +30,7 @@
 #include "Branches/BranchesModel.hpp"
 #include "Branches/BranchesViewData.hpp"
 
+#include "libGitWrap/Operations/CheckoutOperation.hpp"
 
 #include "libGitWrap/Reference.hpp"
 
@@ -99,9 +100,10 @@ void BranchesView::onCheckoutRef()
     const RefBranch *branch = static_cast<const RefBranch *>( srcIndex.internalPointer() );
     if ( !branch ) return;
 
-    Git::Result r;
-    branch->reference().checkout(r);
+    Git::CheckoutReferenceOperation* op = new Git::CheckoutReferenceOperation( branch->reference() );
+    op->execute();
 
+    Git::Result r = op->result();
     if ( !r )
     {
         QMessageBox::warning( this, trUtf8("Error while checking out reference."),

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -14,6 +14,8 @@
  *
  */
 
+#include "Branches/BranchesView.hpp"
+
 #include <QContextMenuEvent>
 #include <QMessageBox>
 #include <QTreeView>
@@ -21,15 +23,15 @@
 #include "libMacGitverCore/App/MacGitver.hpp"
 #include "libMacGitverCore/RepoMan/RepoMan.hpp"
 
-#include "Branches/BranchesView.hpp"
-#include "Branches/BranchesModel.hpp"
-#include "Branches/BranchesViewData.hpp"
-
-#include "libGitWrap/Reference.hpp"
-
 #include "RefItem.hpp"
 #include "RefsSortProxy.hpp"
 #include "RefRenameDialog.hpp"
+
+#include "Branches/BranchesModel.hpp"
+#include "Branches/BranchesViewData.hpp"
+
+
+#include "libGitWrap/Reference.hpp"
 
 
 BranchesView::BranchesView()

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -101,6 +101,9 @@ void BranchesView::onCheckoutRef()
     if ( !branch ) return;
 
     Git::CheckoutReferenceOperation* op = new Git::CheckoutReferenceOperation( branch->reference() );
+    op->setMode( Git::CheckoutSafe );
+    op->setStrategy( Git::CheckoutUpdateHEAD | Git::CheckoutAllowConflicts );
+    // TODO: setBackgroundMode( true );
     op->execute();
 
     Git::Result r = op->result();

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -226,41 +226,6 @@ void BranchesView::onRenameRef()
     }
 }
 
-void BranchesView::onJumpToCurrentBranch()
-{
-    Git::Repository repo = MacGitver::repoMan().activeRepository()->gitRepo();
-
-    if ( !repo.isValid() ) return;
-
-    if ( repo.isHeadDetached() )
-    {
-        QMessageBox::information( this, trUtf8("No branch active"),
-                                  trUtf8("There's currently no branch active on the HEAD commit.") );
-        return;
-    }
-
-    QModelIndexList refIndexes = mData->mModel->match( mData->mModel->index(0, 0),
-                                                       RefItem::TypeRole, RefItem::Reference,
-                                                       -1, Qt::MatchRecursive | Qt::MatchExactly );
-    QModelIndex foundIndex;
-    foreach ( const QModelIndex& index, refIndexes )
-    {
-        const RefBranch* item = static_cast<const RefBranch*>(index.internalPointer());
-        if ( item && item->reference().isCurrentBranch() )
-        {
-            foundIndex = index;
-            break;
-        }
-    }
-
-    if ( foundIndex.isValid() )
-    {
-        QModelIndex proxyIndex = mData->mSortProxy->mapFromSource( foundIndex );
-        mTree->scrollTo( proxyIndex );
-        mTree->selectionModel()->select( proxyIndex, QItemSelectionModel::SelectCurrent );
-    }
-}
-
 void BranchesView::actionFailed( const Git::Result& error )
 {
     if ( error ) return;

--- a/RefsViews/Branches/BranchesViewActions.hid
+++ b/RefsViews/Branches/BranchesViewActions.hid
@@ -35,12 +35,7 @@ Ui BranchesViewActions {
     };
 
     ToolBar BranchesTB {
-
-        Action          JumpToCurrentBranch {
-            Text        "Jump to current branch";
-            ConnectTo   onJumpToCurrentBranch();
-        };
-
+        // placeholder for the real toolbar
     };
 
     Menu CtxMenuRefsView {

--- a/Repository/CMakeLists.txt
+++ b/Repository/CMakeLists.txt
@@ -18,6 +18,7 @@ SET( SRC_FILES
 
     CreateRepositoryDlg.cpp
     CloneRepositoryDlg.cpp
+    CloneOptionsWdgt.cpp
     ProgressDlg.cpp
 )
 
@@ -31,6 +32,7 @@ SET( HDR_FILES
 
     CreateRepositoryDlg.h
     CloneRepositoryDlg.h
+    CloneOptionsWdgt.hpp
     ProgressDlg.hpp
 )
 
@@ -38,6 +40,7 @@ SET( UI_FILES
 
     CreateRepositoryDlg.ui
     CloneRepositoryDlg.ui
+    CloneOptionsWdgt.ui
     ProgressDlg.ui
 )
 

--- a/Repository/CloneOptionsWdgt.cpp
+++ b/Repository/CloneOptionsWdgt.cpp
@@ -1,0 +1,28 @@
+#include "CloneOptionsWdgt.hpp"
+
+
+CloneOptionsWdgt::CloneOptionsWdgt(QWidget *parent) :
+    QWidget(parent)
+{
+    setupUi(this);
+}
+
+CloneOptionsWdgt::~CloneOptionsWdgt()
+{
+}
+
+void CloneOptionsWdgt::on_txtCloneMode_currentIndexChanged(int index)
+{
+    // Clone modes are fixed
+    mCloneMode = static_cast<CloneMode>( index );
+    grpSubmodules->setEnabled( mCloneMode == cmCheckout );
+}
+
+void CloneOptionsWdgt::on_chkInitSubmodules_toggled(bool checked)
+{
+    chkSubmodulesRecursive->setEnabled( checked );
+    if( !checked )
+    {
+        chkSubmodulesRecursive->setChecked( false );
+    }
+}

--- a/Repository/CloneOptionsWdgt.cpp
+++ b/Repository/CloneOptionsWdgt.cpp
@@ -1,10 +1,15 @@
 #include "CloneOptionsWdgt.hpp"
 
+#include <QLayout>
+
 
 CloneOptionsWdgt::CloneOptionsWdgt(QWidget *parent) :
     QWidget(parent)
 {
     setupUi(this);
+
+    // margin is controlled by the parent widget's layout
+    layout()->setMargin(0);
 }
 
 CloneOptionsWdgt::~CloneOptionsWdgt()
@@ -13,7 +18,7 @@ CloneOptionsWdgt::~CloneOptionsWdgt()
 
 void CloneOptionsWdgt::on_txtCloneMode_currentIndexChanged(int index)
 {
-    // Clone modes are fixed
+    // Note: clone modes are fixed
     mCloneMode = static_cast<CloneMode>( index );
     grpSubmodules->setEnabled( mCloneMode == cmCheckout );
 }

--- a/Repository/CloneOptionsWdgt.hpp
+++ b/Repository/CloneOptionsWdgt.hpp
@@ -1,0 +1,35 @@
+#ifndef UICLONEOPTIONS_HPP
+#define UICLONEOPTIONS_HPP
+
+#include <QWidget>
+
+#include "ui_CloneOptionsWdgt.h"
+
+
+class CloneOptionsWdgt : public QWidget, Ui::CloneOptionsWdgt
+{
+    Q_OBJECT
+
+    friend class CloneRepositoryDlg;
+
+public:
+    enum CloneMode {
+        cmCheckout  = 0,
+        cmBare,
+        cmMirror
+    };
+
+public:
+    explicit CloneOptionsWdgt(QWidget *parent = 0);
+    ~CloneOptionsWdgt();
+
+private slots:
+    void on_txtCloneMode_currentIndexChanged(int index);
+
+    void on_chkInitSubmodules_toggled(bool checked);
+
+private:
+    CloneMode       mCloneMode;
+};
+
+#endif // UICLONEOPTIONS_HPP

--- a/Repository/CloneOptionsWdgt.ui
+++ b/Repository/CloneOptionsWdgt.ui
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CloneOptionsWdgt</class>
+ <widget class="QWidget" name="CloneOptionsWdgt">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>624</width>
+    <height>111</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Repository Type:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QComboBox" name="txtCloneMode">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>Normal</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Bare</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Mirror</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="0" column="4" rowspan="3">
+    <widget class="QGroupBox" name="grpSubmodules">
+     <property name="title">
+      <string>Submodules</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Depth:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkInitSubmodules">
+        <property name="text">
+         <string>Initialize submodules</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QCheckBox" name="chkSubmodulesRecursive">
+        <property name="text">
+         <string>Recursive</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="txtSMCloneDepth">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::PlusMinus</enum>
+        </property>
+        <property name="specialValueText">
+         <string>(full depth)</string>
+        </property>
+        <property name="prefix">
+         <string>Depth: </string>
+        </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+        <property name="singleStep">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Branch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QLineEdit" name="txtBranch">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>(default branch)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QCheckBox" name="chkSingleBranch">
+     <property name="text">
+      <string>Single Branch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Depth:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QSpinBox" name="txtCloneDepth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::PlusMinus</enum>
+     </property>
+     <property name="specialValueText">
+      <string>(full depth)</string>
+     </property>
+     <property name="prefix">
+      <string/>
+     </property>
+     <property name="maximum">
+      <number>999999999</number>
+     </property>
+     <property name="singleStep">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Repository/CloneOptionsWdgt.ui
+++ b/Repository/CloneOptionsWdgt.ui
@@ -6,28 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>624</width>
-    <height>111</height>
+    <width>630</width>
+    <height>120</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label_5">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Repository Type:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
+   <item row="1" column="2">
     <widget class="QComboBox" name="txtCloneMode">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -52,7 +39,55 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="4" rowspan="3">
+   <item row="2" column="1" colspan="2">
+    <widget class="QLineEdit" name="txtBranch">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>(default branch)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Repository Type:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QSpinBox" name="txtCloneDepth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::PlusMinus</enum>
+     </property>
+     <property name="specialValueText">
+      <string>(full depth)</string>
+     </property>
+     <property name="prefix">
+      <string/>
+     </property>
+     <property name="maximum">
+      <number>999999999</number>
+     </property>
+     <property name="singleStep">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4" rowspan="3">
     <widget class="QGroupBox" name="grpSubmodules">
      <property name="title">
       <string>Submodules</string>
@@ -122,37 +157,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Branch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QLineEdit" name="txtBranch">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="placeholderText">
-      <string>(default branch)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QCheckBox" name="chkSingleBranch">
-     <property name="text">
-      <string>Single Branch</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_6">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -165,28 +170,49 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QSpinBox" name="txtCloneDepth">
+   <item row="2" column="3">
+    <widget class="QCheckBox" name="chkSingleBranch">
+     <property name="text">
+      <string>Single Branch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_4">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="buttonSymbols">
-      <enum>QAbstractSpinBox::PlusMinus</enum>
+     <property name="text">
+      <string>Branch:</string>
      </property>
-     <property name="specialValueText">
-      <string>(full depth)</string>
+    </widget>
+   </item>
+   <item row="1" column="5" rowspan="3">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="prefix">
-      <string/>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
      </property>
-     <property name="maximum">
-      <number>999999999</number>
+    </spacer>
+   </item>
+   <item row="0" column="0" colspan="6">
+    <widget class="Line" name="line">
+     <property name="styleSheet">
+      <string notr="true">Line{ color: silver; }</string>
      </property>
-     <property name="singleStep">
-      <number>10</number>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/Repository/CloneRepositoryDlg.cpp
+++ b/Repository/CloneRepositoryDlg.cpp
@@ -106,10 +106,13 @@ void CloneRepositoryDlg::accept()
     clone->setBackgroundMode( true );
     clone->setUrl( repoName );
     clone->setPath( targetDir );
+    clone->setRemoteAlias( txtRemoteAlias->text() );
 
     if ( mCloneOpts )
     {
         clone->setBare( mCloneOpts->mCloneMode == CloneOptionsWdgt::cmBare );
+        clone->setReference( mCloneOpts->txtBranch->text() );
+        clone->setDepth( mCloneOpts->txtCloneDepth->value() );
     }
 
     mProgress = new ProgressDlg;

--- a/Repository/CloneRepositoryDlg.cpp
+++ b/Repository/CloneRepositoryDlg.cpp
@@ -153,6 +153,12 @@ void CloneRepositoryDlg::beginDownloading()
     updateAction();
 }
 
+void CloneRepositoryDlg::doneDownload()
+{
+    mStates[ Download ] = Done;
+    updateAction();
+}
+
 void CloneRepositoryDlg::doneIndexing()
 {
     mStates[ Index ] = Done;
@@ -169,10 +175,7 @@ void CloneRepositoryDlg::doneCheckout()
     updateAction();
 }
 
-void CloneRepositoryDlg::doneDownload()
 {
-    mStates[ Download ] = Done;
-    updateAction();
 }
 
 void CloneRepositoryDlg::updateAction()

--- a/Repository/CloneRepositoryDlg.cpp
+++ b/Repository/CloneRepositoryDlg.cpp
@@ -106,7 +106,11 @@ void CloneRepositoryDlg::accept()
     clone->setBackgroundMode( true );
     clone->setUrl( repoName );
     clone->setPath( targetDir );
-    clone->setBare( mCloneOpts && (mCloneOpts->mCloneMode == CloneOptionsWdgt::cmBare) );
+
+    if ( mCloneOpts )
+    {
+        clone->setBare( mCloneOpts->mCloneMode == CloneOptionsWdgt::cmBare );
+    }
 
     mProgress = new ProgressDlg;
     mProgress->show();

--- a/Repository/CloneRepositoryDlg.cpp
+++ b/Repository/CloneRepositoryDlg.cpp
@@ -96,8 +96,15 @@ void CloneRepositoryDlg::checkValid()
 void CloneRepositoryDlg::accept()
 {
     Git::CloneOperation* clone = new Git::CloneOperation( this );
-    QString repoName = txtUrl->text();
-    QString targetDir = txtPath->text();
+    QString repoName  = QUrl( txtUrl->text() ).adjusted( QUrl::NormalizePathSegments | QUrl::StripTrailingSlash ).toString();
+    QString targetDir = QUrl( txtPath->text() ).adjusted( QUrl::NormalizePathSegments | QUrl::StripTrailingSlash ).toString();
+
+    if ( chkAppendRepoName->isChecked() )
+    {
+        targetDir += QString::fromUtf8("/%1")
+                    .arg( QUrl( repoName ).fileName() );
+    }
+
     clone->setBackgroundMode( true );
     clone->setUrl( repoName );
     clone->setPath( targetDir );

--- a/Repository/CloneRepositoryDlg.cpp
+++ b/Repository/CloneRepositoryDlg.cpp
@@ -75,10 +75,8 @@ void CloneRepositoryDlg::onBrowseHelper( const QString& directory )
 
 void CloneRepositoryDlg::checkValid()
 {
-    bool okay =
-            !txtPath->text().isEmpty() &&
-            !txtUrl->text().isEmpty() &&
-            !txtRemoteName->text().isEmpty();
+    bool okay = !txtPath->text().isEmpty() &&
+                !txtUrl->text().isEmpty();
 
     QDir wanted( QDir::toNativeSeparators( txtPath->text() ) );
     if( wanted.exists() )

--- a/Repository/CloneRepositoryDlg.h
+++ b/Repository/CloneRepositoryDlg.h
@@ -19,7 +19,10 @@
 
 #include "ui_CloneRepositoryDlg.h"
 
+#include <QPointer>
+
 class ProgressDlg;
+class CloneOptionsWdgt;
 
 class CloneRepositoryDlg : public QDialog, Ui::CloneRepositoryDlg
 {
@@ -33,9 +36,6 @@ protected:
 private slots:
     void onBrowse();
     void onBrowseHelper( const QString& directory );
-    void onCheckout( bool value );
-    void onInitSubmodules( bool value );
-    void onCheckoutBranch( const QString& branch );
     void checkValid();
 
     void doneIndexing();
@@ -44,15 +44,22 @@ private slots:
     void beginDownloading();
     void rootCloneFinished();
 
+    void on_btnCloneopts_toggled(bool checked);
+
+private:
+    enum State { Unused, Open, Done, Current };
+    enum Tasks { Prepare, Download, Index, Checkout };
+
 private:
     void updateAction();
 
 private:
-    ProgressDlg* mProgress;
-    QString mAction;
-    enum State { Unused, Open, Done, Current };
-    enum Tasks { Prepare, Download, Index, Checkout };
-    QHash< Tasks, State > mStates;
+    QPointer<CloneOptionsWdgt>     mCloneOpts;
+
+    ProgressDlg*                mProgress;
+    QString                     mAction;
+    QHash< Tasks, State >       mStates;
+
 };
 
 #endif

--- a/Repository/CloneRepositoryDlg.h
+++ b/Repository/CloneRepositoryDlg.h
@@ -38,10 +38,10 @@ private slots:
     void onBrowseHelper( const QString& directory );
     void checkValid();
 
+    void beginDownloading();
+    void doneDownload();
     void doneIndexing();
     void doneCheckout();
-    void doneDownload();
-    void beginDownloading();
     void rootCloneFinished();
 
     void on_btnCloneopts_toggled(bool checked);

--- a/Repository/CloneRepositoryDlg.ui
+++ b/Repository/CloneRepositoryDlg.ui
@@ -112,27 +112,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="2" column="0" colspan="6">
+    <layout class="QVBoxLayout" name="optsLayout">
+     <property name="spacing">
+      <number>0</number>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
+    </layout>
    </item>
    <item row="0" column="3">
-    <widget class="QToolButton" name="btnBrowseFrom">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="4">
     <widget class="QLabel" name="label_3">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -148,10 +135,10 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="5">
+   <item row="0" column="4" colspan="2">
     <widget class="LineEdit" name="txtRemoteName">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -164,12 +151,18 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="6">
-    <layout class="QVBoxLayout" name="optsLayout">
-     <property name="spacing">
-      <number>0</number>
+   <item row="3" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </layout>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/Repository/CloneRepositoryDlg.ui
+++ b/Repository/CloneRepositoryDlg.ui
@@ -144,6 +144,9 @@
       </sizepolicy>
      </property>
      <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
       <string>origin</string>
      </property>
      <property name="mandatory" stdset="0">

--- a/Repository/CloneRepositoryDlg.ui
+++ b/Repository/CloneRepositoryDlg.ui
@@ -131,12 +131,12 @@
       <string>Alias:</string>
      </property>
      <property name="buddy">
-      <cstring>txtRemoteName</cstring>
+      <cstring>txtRemoteAlias</cstring>
      </property>
     </widget>
    </item>
    <item row="0" column="4" colspan="2">
-    <widget class="LineEdit" name="txtRemoteName">
+    <widget class="LineEdit" name="txtRemoteAlias">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>

--- a/Repository/CloneRepositoryDlg.ui
+++ b/Repository/CloneRepositoryDlg.ui
@@ -6,186 +6,103 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>370</width>
-    <height>357</height>
+    <width>602</width>
+    <height>107</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Clone repository</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>From</string>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0" colspan="2">
+    <widget class="QPushButton" name="btnCloneopts">
+     <property name="text">
+      <string>Clone Options</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="2">
-       <widget class="LineEdit" name="txtUrl">
-        <property name="mandatory" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="LineEdit" name="txtRemoteName">
-        <property name="text">
-         <string>origin</string>
-        </property>
-        <property name="mandatory" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Url</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtUrl</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Remote</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtRemoteName</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>To</string>
+   <item row="1" column="4" colspan="2">
+    <widget class="QCheckBox" name="chkAppendRepoName">
+     <property name="text">
+      <string>Append repository name</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Path</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtPath</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="LineEdit" name="txtPath">
-        <property name="mandatory" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="btnBrowse">
-        <property name="text">
-         <string>&amp;Browse</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Options</string>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="7" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkInitSubmodules">
-        <property name="text">
-         <string>Initialize submodules</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="2">
-       <widget class="QCheckBox" name="chkSubmodulesRecursive">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Recursively</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtCheckoutBranch">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="placeholderText">
-         <string>Branch to checkout (default if empty)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="3">
-       <widget class="QCheckBox" name="chkFetchOne">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Fetch only the branch to be checked out</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="3">
-       <widget class="QRadioButton" name="chkCloneBare">
-        <property name="text">
-         <string>Clone Bare Repository</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="3">
-       <widget class="QRadioButton" name="chkCloneMirror">
-        <property name="text">
-         <string>Clone as mirror</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="chkCheckout">
-        <property name="text">
-         <string>Checkout</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="text">
+      <string>To:</string>
+     </property>
+     <property name="buddy">
+      <cstring>txtPath</cstring>
+     </property>
     </widget>
    </item>
-   <item>
+   <item row="1" column="1" colspan="2">
+    <widget class="LineEdit" name="txtPath">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="mandatory" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QToolButton" name="btnBrowseTo">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="LineEdit" name="txtUrl">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="mandatory" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>From:</string>
+     </property>
+     <property name="buddy">
+      <cstring>txtUrl</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -194,6 +111,65 @@
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="3" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="3">
+    <widget class="QToolButton" name="btnBrowseFrom">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Alias:</string>
+     </property>
+     <property name="buddy">
+      <cstring>txtRemoteName</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="5">
+    <widget class="LineEdit" name="txtRemoteName">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>origin</string>
+     </property>
+     <property name="mandatory" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="6">
+    <layout class="QVBoxLayout" name="optsLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -206,17 +182,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>txtUrl</tabstop>
-  <tabstop>txtRemoteName</tabstop>
   <tabstop>txtPath</tabstop>
-  <tabstop>btnBrowse</tabstop>
-  <tabstop>chkCloneBare</tabstop>
-  <tabstop>chkCloneMirror</tabstop>
-  <tabstop>chkCheckout</tabstop>
-  <tabstop>txtCheckoutBranch</tabstop>
-  <tabstop>chkFetchOne</tabstop>
-  <tabstop>chkInitSubmodules</tabstop>
-  <tabstop>chkSubmodulesRecursive</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>chkAppendRepoName</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/Repository/ProgressDlg.cpp
+++ b/Repository/ProgressDlg.cpp
@@ -15,7 +15,7 @@ ProgressDlg::ProgressDlg()
 
     QPushButton* close = buttonBox->button( QDialogButtonBox::Close );
     close->setEnabled( false );
-    connect( close, SIGNAL(clicked()), this, SLOT(reject()) );
+    connect( close, SIGNAL(clicked()), this, SLOT(close ()) );
 
     QPalette p;
     p.setColor( QPalette::Base, p.color( QPalette::Window ) );

--- a/Repository/ProgressDlg.cpp
+++ b/Repository/ProgressDlg.cpp
@@ -7,6 +7,7 @@
 
 #include "ProgressDlg.hpp"
 
+
 ProgressDlg::ProgressDlg()
     : BlueSky::Dialog()
     , mDone( false )
@@ -49,13 +50,12 @@ void ProgressDlg::setAction( const QString& action,
     lblAction->setText( act );
 }
 
-void ProgressDlg::setCurrent( QObject* current )
+void ProgressDlg::setCurrent(QObject* current)
 {
     mCurrent = current;
 
     connect( mCurrent, SIGNAL(remoteMessage(QString)),
              this, SLOT(remoteMessage(QString)) );
-
     connect( mCurrent, SIGNAL(transportProgress(quint32, quint32, quint32, quint64)),
              this, SLOT(transportProgress(quint32, quint32, quint32, quint64)) );
 }

--- a/Repository/ProgressDlg.hpp
+++ b/Repository/ProgressDlg.hpp
@@ -6,6 +6,7 @@
 
 #include "ui_ProgressDlg.h"
 
+
 class ProgressDlg
         : public BlueSky::Dialog
         , private Ui::ProgressDlg
@@ -17,7 +18,7 @@ public:
 public:
     void setAction( const QString& action, const QStringList& open,
                     const QStringList& current, const QStringList& done );
-    void setCurrent( QObject* current );
+    void setCurrent(QObject* current);
 
 private slots:
     void transportProgress( quint32 totalObjects, quint32 indexedObjects,

--- a/Repository/RepositoryModule.cpp
+++ b/Repository/RepositoryModule.cpp
@@ -58,9 +58,6 @@ void RepositoryModule::initialize()
     connect(&MacGitver::repoMan(),  SIGNAL(repositoryOpened(RM::Repo*)),
             this,                   SLOT(onCoreRepoOpen(RM::Repo*)));
 
-    connect(&MacGitver::repoMan(),  SIGNAL(hasActiveRepositoryChanged(bool)),
-            actRepositoryClose,     SLOT(setEnabled(bool)));
-
     updateMostRecentlyUsedMenu();
 
     registerView<RepoTreeView>(tr("Repository"));

--- a/Repository/RepositoryModule.hid
+++ b/Repository/RepositoryModule.hid
@@ -25,12 +25,6 @@ Ui RepositoryActions {
         ConnectTo           onRepositoryOpen();
     };
 
-    Action RepositoryClose {
-        Text        "C&lose";
-        Enabled     false;
-        ConnectTo   onRepositoryClose();
-    };
-
     Action RepositoryClone {
         Text        "&Clone...";
         ConnectTo   onRepositoryClone();
@@ -52,7 +46,6 @@ Ui RepositoryActions {
 
         Action      RepositoryOpen;
         Menu        RepoOpenRecent;
-        Action      RepositoryClose;
         Separator;
         Action      RepositoryCreate;
         Action      RepositoryClone;
@@ -63,7 +56,6 @@ Ui RepositoryActions {
 
         Action      RepositoryOpen;
         Action      RepositoryClone;
-        Action      RepositoryClose;
 
     };
 

--- a/WorkingTree/CommitDialog.cpp
+++ b/WorkingTree/CommitDialog.cpp
@@ -77,9 +77,10 @@ void CommitDialog::onCommit()
     Git::Repository gitRepo = repo->gitRepo();
 
     QScopedPointer<Git::CommitOperation> op( gitRepo.commitOperation( r, ui->textCommitMessage->toPlainText() ) );
-    if (op)
+    if ( op && r )
     {
-        r = op->execute();
+        op->execute();
+        r = op->result();
     }
 
     if (!r)

--- a/WorkingTree/CommitDialog.cpp
+++ b/WorkingTree/CommitDialog.cpp
@@ -83,7 +83,7 @@ void CommitDialog::onCommit()
         r = op->result();
     }
 
-    if (!r)
+    if ( !r )
     {
         QMessageBox::information( this, trUtf8("Failed to commit"),
                                   trUtf8("Failed to commit. Git message:\n%1").arg(r.errorText()));


### PR DESCRIPTION
Here it comes! A polished version of our clone dialog - and more.

The dialog is expandable to show more options, but in its initial state it shows the very simplified version.

:exclamation: Note: Depends on [PR 63 in GitWrap](https://github.com/macgitver/libGitWrap/pull/63).

This is crucial for the following reasons:
- Especially new users to Git will appreciate a small user interface without the screen flooded with options (even if they are all preset with the correct values).
- The workflow must be reasonably fast. Thus, it should be editable just by the keyboard at hand.

For everything else, there's the options panel. When expanding the options, we have three "modes" available (currently titled with "Repository Type"):
- Normal: Creates a normal Git clone of an existing repo, followed by a checkout to the working directory.
- Bare: Creates a bare clone. In this mode, submodule options are not available.
- Mirror: :construction: (not implemented yet) This is a mirrored bare clone of an existing repository.

TODO:
- [x] Complete implementation of options.
- [x] Append the repository name to the destination path, when the checkbox is checked. ~~For a bare clone, it should end with `.git`~~
  - At the moment, simply the last segment of "From-URL" is appended. See on Redmine: http://redmine.macgitver.info/issues/214
- [x] States are not completing correctly, which is actually still a bug :beetle:.
- [x] ~~Support `alternates` (See Git clone docs: http://git-scm.com/docs/git-clone)~~
  Not realized in this PR. See redmine (http://redmine.macgitver.info/issues/212)

As of API changes to GW, there'll be more features available:
- [x] Checkout a commit: updates HEAD and index correctly
- [x] Checkout a branch / reference works

Other changes:
- [x] Removed "Close" action from Main menu.
  - It does not work and - at this state - just clutters the menu with useless features. It may be re-added later with lots of polishment.
- [x] Removed "Jump to current branch" action from Refs-View
  - Will be moved to another place and become "Show HEAD".
- [x] Creation of lightweight tags on any commit in history view.
