### PR TITLE
migrate refitem to use RM::Ref

### DIFF
--- a/History/HistoryBuilder.cpp
+++ b/History/HistoryBuilder.cpp
@@ -71,14 +71,14 @@ void HistoryBuilder::addBranches(bool includeRemotes)
 
     QStringList sl = mRepo.branchNames(r, true, false);
     foreach (const QString& s, sl) {
-        mWalker.pushRef(r, QLatin1Literal("refs/heads/") % s);
+        mWalker.pushRef(r, QStringLiteral("refs/heads/") % s);
     }
 
     if (includeRemotes) {
         sl = mRepo.branchNames(r, false, true);
 
         foreach (const QString& s, sl) {
-            mWalker.pushRef(r, QLatin1Literal("refs/remotes/") % s);
+            mWalker.pushRef(r, QStringLiteral("refs/remotes/") % s);
         }
     }
 }

--- a/History/HistoryDiff.cpp
+++ b/History/HistoryDiff.cpp
@@ -52,6 +52,8 @@ HistoryDiff::HistoryDiff()
     mToolbar = new QToolBar;
 
     mDiffTo = new QComboBox;
+    mDiffTo->addItem( trUtf8( "All parents" ), DTT_AllParents );
+    mDiffTo->addItem( trUtf8( "Parent" ), DTT_Parent );
     mDiffTo->addItem( trUtf8( "Workingtree" ), DTT_WT );
     mDiffTo->addItem( trUtf8( "Index" ), DTT_Index );
     mDiffTo->addItem( trUtf8( "Workingtree + Index" ), DTT_WT_and_Index );
@@ -59,8 +61,6 @@ HistoryDiff::HistoryDiff()
     //mDiffTo->addItem( trUtf8( "SHA-1" ), DTT_AnySHA1 );
     mDiffTo->addItem( trUtf8( "Branch" ), DTT_Branch );
     mDiffTo->addItem( trUtf8( "Tag" ), DTT_Tag );
-    mDiffTo->addItem( trUtf8( "All parents" ), DTT_AllParents );
-    mDiffTo->addItem( trUtf8( "Parent" ), DTT_Parent );
 
     mToolbar->addWidget( new QLabel( trUtf8( "Diff to:" ) ) );
     mToolbar->addWidget( mDiffTo );

--- a/History/HistoryEntry.h
+++ b/History/HistoryEntry.h
@@ -70,7 +70,6 @@ struct HistoryInlineRef
         }
 
         return  mRefName    == other.mRefName       &&
-                mRefName    == other.mRefName       &&
                 mIsBranch   == other.mIsBranch      &&
                 mIsCurrent  == other.mIsCurrent     &&
                 mIsRemote   == other.mIsRemote      &&

--- a/History/HistoryEntry.h
+++ b/History/HistoryEntry.h
@@ -61,9 +61,86 @@ struct HistoryInlineRef
     bool        mIsRemote   : 1;
     bool        mIsTag      : 1;
     bool        mIsStash    : 1;
+    bool        mIsDetached : 1;
+
+    bool operator ==(const HistoryInlineRef& other) const
+    {
+        if ( this == &other ) {
+            return true;
+        }
+
+        return  mRefName    == other.mRefName       &&
+                mRefName    == other.mRefName       &&
+                mIsBranch   == other.mIsBranch      &&
+                mIsCurrent  == other.mIsCurrent     &&
+                mIsRemote   == other.mIsRemote      &&
+                mIsTag      == other.mIsTag         &&
+                mIsStash    == other.mIsStash       &&
+                mIsDetached == other.mIsDetached    ;
+    }
+
+    inline bool operator !=(const HistoryInlineRef& other) const {
+        return !( *this == other );
+    }
 };
 
-typedef QVector< HistoryInlineRef > HistoryInlineRefs;
+typedef QList< HistoryInlineRef > HistoryInlineRefs;
+
+struct HistoryInlineRef_LessThan
+{
+    inline bool detachedHEAD(const HistoryInlineRef& ref) const
+    {
+        return ref.mIsDetached && !(ref.mIsTag || ref.mIsBranch || ref.mIsStash);
+    }
+
+    inline bool nameLessThan(const HistoryInlineRef& a, const HistoryInlineRef& b) const
+    {
+        return a.mRefName < b.mRefName;
+    }
+
+    bool operator ()(const HistoryInlineRef& a, const HistoryInlineRef& b) const
+    {
+        // sort order:
+        // - tag
+        // - detached HEAD
+        // - current branch
+        // - local branch
+        // - remote branch
+        // - stash
+        // - Everything else is sorted by mRefName
+
+        if ( a.mIsTag ) {
+            // tags have highest priority
+            return b.mIsTag ? nameLessThan(a, b) : true;
+        }
+
+        if ( detachedHEAD( a ) )
+        {
+            // a detached HEAD comes right after tag ? -> There can only be one!
+            return !b.mIsTag;
+        }
+
+        if ( a.mIsBranch )
+        {
+            if ( b.mIsTag || b.mIsCurrent || detachedHEAD( b ) )
+                return false;
+
+            if ( a.mIsCurrent ) {
+                // a is the current branch
+                return true;
+            }
+
+            return ( a.mIsRemote == b.mIsRemote ) ? nameLessThan( a, b ) : !a.mIsRemote;
+        }
+
+        if ( a.mIsStash ) {
+            return b.mIsStash ? nameLessThan(a, b) : !(b.mIsTag || b.mIsBranch || detachedHEAD( b ));
+        }
+
+        return !(b.mIsTag || b.mIsBranch || b.mIsStash || detachedHEAD( b )) ? nameLessThan( a, b ) : false;
+    }
+};
+
 
 class HistoryEntry
 {

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -304,7 +304,11 @@ QColor HistoryListDelegate::colorForRefType(const HistoryInlineRef& ref) const
         return QColor::fromHsl(89, 255, 190);
     }
 
-    return QColor( 0xD9D9D9 );
+    if ( ref.mIsStash )
+        return QColor( 0xD9D9D9 );
+
+    // DETACHED REF
+    return QColor( 0xFF5959 );
 }
 
 void HistoryListDelegate::paintMessage( QPainter* p, const QStyleOptionViewItem& opt,

--- a/History/HistoryListDelegate.cpp
+++ b/History/HistoryListDelegate.cpp
@@ -244,7 +244,7 @@ void HistoryListDelegate::paintGraph( QPainter* p, const QStyleOptionViewItem& o
 
     if( !e )
     {
-        // If we're still required to populate that entry, don't do anyhting here
+        // If we're still required to populate that entry, don't do anything here
         return;
     }
 

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -21,6 +21,8 @@
 #include <QElapsedTimer>
 
 #include "libMacGitverCore/App/MacGitver.hpp"
+#include "libMacGitverCore/RepoMan/RepoMan.hpp"
+#include "libMacGitverCore/RepoMan/Ref.hpp"
 
 #include "libGitWrap/Reference.hpp"
 
@@ -37,6 +39,8 @@ HistoryModel::HistoryModel( const Git::Repository& repo, QObject* parent )
 
     mDisplays = 0;
 
+    RM::RepoMan &rm = MacGitver::repoMan();
+    connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
     Q_ASSERT( mRepo.isValid() );
 }
 
@@ -221,6 +225,11 @@ void HistoryModel::beforeAppend()
 void HistoryModel::afterAppend()
 {
     endInsertRows();
+}
+
+void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
+{
+    scanInlineReferences();
 }
 
 void HistoryModel::ensurePopulated( int row )

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -390,43 +390,31 @@ void HistoryModel::scanInlineReferences()
         HistoryInlineRefs newRefs = refsById.value( e->id() );
         HistoryInlineRefs oldRefs = e->refs();
 
-        if( !newRefs.count() )
+        if( oldRefs.count() != newRefs.count() )
         {
-            if( !oldRefs.count() )
-            {
-                continue;
-            }
             e->setInlineRefs( newRefs );
             updateRows( i, i );
+            continue;
         }
-        else
-        {
-            if( oldRefs.count() != newRefs.count() )
-            {
-                e->setInlineRefs( newRefs );
-                updateRows( i, i );
-                continue;
-            }
 
-            int diffs = newRefs.count();
-            for( int j = 0; j < newRefs.count(); j++ )
+        int diffs = newRefs.count();
+        for( int j = 0; j < newRefs.count(); j++ )
+        {
+            QString newRef = newRefs.at( j ).mRefName;
+            for( int k = 0; k < oldRefs.count(); k++ )
             {
-                QString newRef = newRefs.at( j ).mRefName;
-                for( int k = 0; k < oldRefs.count(); k++ )
+                if( oldRefs.at( k ).mRefName == newRef )
                 {
-                    if( oldRefs.at( k ).mRefName == newRef )
-                    {
-                        diffs--;
-                        break;
-                    }
+                    diffs--;
+                    break;
                 }
             }
+        }
 
-            if( diffs )
-            {
-                e->setInlineRefs( newRefs );
-                updateRows( i, i );
-            }
+        if( diffs )
+        {
+            e->setInlineRefs( newRefs );
+            updateRows( i, i );
         }
     }
 

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -377,7 +377,7 @@ void HistoryModel::scanInlineReferences()
             continue;
         }
 
-        const Git::ObjectId &oid = refs[ref];
+        Git::ObjectId oid = refs[ref];
         if ( !refsById.contains( oid ) ) {
             refsById.insert( oid, HistoryInlineRefs() );
         }

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -43,6 +43,7 @@ HistoryModel::HistoryModel( const Git::Repository& repo, QObject* parent )
     RM::RepoMan &rm = MacGitver::repoMan();
     connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
     connect( &rm, SIGNAL(refLinkChanged(RM::Repo*,RM::Ref*)), this, SLOT(onRefLinkChanged(RM::Repo*,RM::Ref*)) );
+    connect( &rm, SIGNAL(refMoved(RM::Repo*,RM::Ref*)), this, SLOT(onRefMoved(RM::Repo*,RM::Ref*)) );
 }
 
 HistoryModel::~HistoryModel()
@@ -234,6 +235,11 @@ void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 }
 
 void HistoryModel::onRefLinkChanged(RM::Repo* repo, RM::Ref* ref)
+{
+    scanInlineReferences();
+}
+
+void HistoryModel::onRefMoved(RM::Repo* repo, RM::Ref* ref)
 {
     scanInlineReferences();
 }

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -42,6 +42,7 @@ HistoryModel::HistoryModel( const Git::Repository& repo, QObject* parent )
 
     RM::RepoMan &rm = MacGitver::repoMan();
     connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
+    connect( &rm, SIGNAL(refAboutToBeDeleted(RM::Repo*,RM::Ref*)), this, SLOT(onRefDestroyed(RM::Repo*,RM::Ref*)) );
     connect( &rm, SIGNAL(refMoved(RM::Repo*,RM::Ref*)), this, SLOT(onRefMoved(RM::Repo*,RM::Ref*)) );
 }
 
@@ -235,6 +236,11 @@ void HistoryModel::afterAppend()
 ///@{
 
 void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
+{
+    scanInlineReferences();
+}
+
+void HistoryModel::onRefDestroyed(RM::Repo* repo, RM::Ref* ref)
 {
     scanInlineReferences();
 }

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -42,7 +42,6 @@ HistoryModel::HistoryModel( const Git::Repository& repo, QObject* parent )
 
     RM::RepoMan &rm = MacGitver::repoMan();
     connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
-    connect( &rm, SIGNAL(refLinkChanged(RM::Repo*,RM::Ref*)), this, SLOT(onRefLinkChanged(RM::Repo*,RM::Ref*)) );
     connect( &rm, SIGNAL(refMoved(RM::Repo*,RM::Ref*)), this, SLOT(onRefMoved(RM::Repo*,RM::Ref*)) );
 }
 
@@ -229,12 +228,8 @@ void HistoryModel::afterAppend()
     endInsertRows();
 }
 
-void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
-{
-    scanInlineReferences();
-}
 
-void HistoryModel::onRefLinkChanged(RM::Repo* repo, RM::Ref* ref)
+void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 {
     scanInlineReferences();
 }

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -1,6 +1,6 @@
 /*
  * MacGitver
- * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ * Copyright (C) 2015 The MacGitver-Developers <dev@macgitver.org>
  *
  * (C) Sascha Cunz <sascha@macgitver.org>
  * (C) Cunz RaD Ltd.

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -321,7 +321,7 @@ void HistoryModel::scanInlineReferences()
         HistoryInlineRef inlRef;
         inlRef.mIsDetached = detached;
 
-        if (mDisplays.testFlag(DisplayLocals) && ref.startsWith(QLatin1String("refs/heads/"))) {
+        if ( mDisplays.testFlag(DisplayLocals) && ref.startsWith(QLatin1Literal("refs/heads/")) ) {
             inlRef.mRefName = ref.mid( strlen( "refs/heads/" ) );
             inlRef.mIsBranch = true;
             inlRef.mIsRemote = false;
@@ -329,7 +329,7 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsStash = false;
             inlRef.mIsCurrent = inlRef.mRefName == refHEAD.shorthand();
         }
-        else if (mDisplays.testFlag(DisplayTags) && ref.startsWith(QLatin1String("refs/tags/"))) {
+        else if (mDisplays.testFlag( DisplayTags ) && ref.startsWith( QLatin1Literal("refs/tags/") ) ) {
             inlRef.mRefName = ref.mid( strlen( "refs/tags/" ) );
             inlRef.mIsBranch = false;
             inlRef.mIsRemote = false;
@@ -338,9 +338,9 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsStash = false;
         }
         else if (mDisplays.testFlag(DisplayRemotes) &&
-                 ref.startsWith(QLatin1String("refs/remotes/"))) {
+                 ref.startsWith( QLatin1Literal("refs/remotes/")) ) {
 
-            if (ref.endsWith( QLatin1String("HEAD"))) {
+            if (ref.endsWith( QLatin1Literal("HEAD"))) {
                 continue; // Skip "HEAD"
             }
             inlRef.mRefName = ref.mid( strlen( "refs/remotes/" ) );
@@ -350,8 +350,8 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsCurrent = false;
             inlRef.mIsStash = false;
         }
-        else if (ref == QLatin1String("refs/stash")) {
-            inlRef.mRefName = trUtf8( "<recent stash>" );
+        else if (ref == QLatin1Literal("refs/stash")) {
+            inlRef.mRefName = tr( "<recent stash>" );
             inlRef.mIsBranch = false;
             inlRef.mIsCurrent = true;
             inlRef.mIsRemote = false;

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -409,24 +409,14 @@ void HistoryModel::updateInlineRefs(const QHash<Git::ObjectId, HistoryInlineRefs
             continue;
         }
 
-        int diffs = newRefs.count();
-        for( int j = 0; j < newRefs.count(); j++ )
-        {
-            QString newRef = newRefs.at( j ).mRefName;
-            for( int k = 0; k < oldRefs.count(); k++ )
-            {
-                if( oldRefs.at( k ).mRefName == newRef )
-                {
-                    diffs--;
-                    break;
-                }
+        for ( int j = 0; j < newRefs.count(); j++ ) {
+            const HistoryInlineRef& newRef = newRefs[j];
+            const HistoryInlineRef& oldRef = oldRefs[j];
+            if ( newRef != oldRef ) {
+                e->setInlineRefs( newRefs );
+                updateRows( i, i );
+                break;
             }
-        }
-
-        if( diffs )
-        {
-            e->setInlineRefs( newRefs );
-            updateRows( i, i );
         }
     }
 }

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -236,16 +236,34 @@ void HistoryModel::afterAppend()
 ///@{
 void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 {
+    Q_UNUSED( ref )
+
+    if ( !repo || (repo->gitLoadedRepo() != mRepo) ) {
+        return;
+    }
+
     scanInlineReferences();
 }
 
 void HistoryModel::onRefDestroyed(RM::Repo* repo, RM::Ref* ref)
 {
+    Q_UNUSED( ref )
+
+    if ( !repo || (repo->gitLoadedRepo() != mRepo) ) {
+        return;
+    }
+
     scanInlineReferences();
 }
 
 void HistoryModel::onRefMoved(RM::Repo* repo, RM::Ref* ref)
 {
+    Q_UNUSED( ref );
+
+    if ( !repo || (repo->gitLoadedRepo() != mRepo) ) {
+        return;
+    }
+
     scanInlineReferences();
 }
 ///@}

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -406,8 +406,6 @@ void HistoryModel::scanInlineReferences()
 
 void HistoryModel::updateInlineRefs(const QHash<Git::ObjectId, HistoryInlineRefs>& refsById)
 {
-    HistoryInlineRef_LessThan lt;
-
     for( int i = 0; i < mEntries.count(); i++ )
     {
         HistoryEntry* e = mEntries[i];
@@ -417,7 +415,7 @@ void HistoryModel::updateInlineRefs(const QHash<Git::ObjectId, HistoryInlineRefs
         HistoryInlineRefs oldRefs = e->refs();
 
         // sort newRefs: no need to sort oldRefs as it is already sorted)
-        std::sort( newRefs.begin(), newRefs.end(), lt );
+        std::sort( newRefs.begin(), newRefs.end() );
 
         if( oldRefs.count() != newRefs.count() )
         {

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -234,7 +234,6 @@ void HistoryModel::afterAppend()
  * @see RM::EventInterface
  */
 ///@{
-
 void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 {
     scanInlineReferences();

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -294,22 +294,17 @@ void HistoryModel::scanInlineReferences()
     Git::Reference      refHEAD;
     QHash< Git::ObjectId, HistoryInlineRefs > refsById;
 
-    if( !mRepo.isValid() )
-    {
-        return;
-    }
-
     // First step: Collect all references.
 
     refs = mRepo.allResolvedRefs( r );
     refHEAD = mRepo.HEAD( r );
-    bool detached = mRepo.isHeadDetached();
     if( !r )
     {
         MacGitver::log(Log::Error, r.errorText());
         return;
     }
 
+    bool detached = mRepo.isHeadDetached();
     QElapsedTimer   stopwatch;
     stopwatch.start();
 
@@ -372,11 +367,12 @@ void HistoryModel::scanInlineReferences()
             continue;
         }
 
-        if (!refsById.contains(refs[ref])) {
-            refsById.insert(refs[ref], HistoryInlineRefs());
+        const Git::ObjectId &oid = refs[ref];
+        if ( !refsById.contains( oid ) ) {
+            refsById.insert( oid, HistoryInlineRefs() );
         }
 
-        refsById[refs[ref]].append(inlRef);
+        refsById[ oid ].append( inlRef );
     }
 
     // Third step: Update the commitlist and mix it with the inline Refs we just found.

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -42,6 +42,7 @@ HistoryModel::HistoryModel( const Git::Repository& repo, QObject* parent )
 
     RM::RepoMan &rm = MacGitver::repoMan();
     connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
+    connect( &rm, SIGNAL(refLinkChanged(RM::Repo*,RM::Ref*)), this, SLOT(onRefLinkChanged(RM::Repo*,RM::Ref*)) );
 }
 
 HistoryModel::~HistoryModel()
@@ -228,6 +229,11 @@ void HistoryModel::afterAppend()
 }
 
 void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
+{
+    scanInlineReferences();
+}
+
+void HistoryModel::onRefLinkChanged(RM::Repo* repo, RM::Ref* ref)
 {
     scanInlineReferences();
 }

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -287,11 +287,11 @@ void HistoryModel::buildHistory()
 
 void HistoryModel::scanInlineReferences()
 {
-    qint64				dur;
-    double				avg;
-    Git::ResolvedRefs	refs;
-    Git::Result			r;
-    Git::Reference		refHEAD;
+    qint64              dur;
+    double              avg;
+    Git::ResolvedRefs   refs;
+    Git::Result         r;
+    Git::Reference      refHEAD;
     QHash< Git::ObjectId, HistoryInlineRefs > refsById;
 
     if( !mRepo.isValid() )

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -353,7 +353,7 @@ void HistoryModel::scanInlineReferences()
         else if (ref == QLatin1Literal("refs/stash")) {
             inlRef.mRefName = tr( "<recent stash>" );
             inlRef.mIsBranch = false;
-            inlRef.mIsCurrent = true;
+            inlRef.mIsCurrent = false;
             inlRef.mIsRemote = false;
             inlRef.mIsTag = false;
             inlRef.mIsStash = true;

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -305,6 +305,12 @@ void HistoryModel::scanInlineReferences()
     }
 
     bool detached = mRepo.isHeadDetached();
+    if ( detached ) {
+        // append HEAD when detached
+        refs[QLatin1Literal("< DETACHED >")] =
+                refHEAD.resolveToObjectId( r );
+    }
+
     QElapsedTimer   stopwatch;
     stopwatch.start();
 
@@ -313,20 +319,10 @@ void HistoryModel::scanInlineReferences()
     foreach( QString ref, refs.keys() )
     {
         HistoryInlineRef inlRef;
+        inlRef.mIsDetached = detached;
 
         if (mDisplays.testFlag(DisplayLocals) && ref.startsWith(QLatin1String("refs/heads/"))) {
-            if (ref.endsWith(QLatin1String("HEAD"))) {
-                if (detached) {
-                    inlRef.mRefName = trUtf8("<detached head>");
-                }
-                else {
-                    // Skip "HEAD"
-                    continue;
-                }
-            }
-            else {
-                inlRef.mRefName = ref.mid( strlen( "refs/heads/" ) );
-            }
+            inlRef.mRefName = ref.mid( strlen( "refs/heads/" ) );
             inlRef.mIsBranch = true;
             inlRef.mIsRemote = false;
             inlRef.mIsTag = false;
@@ -361,6 +357,14 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsRemote = false;
             inlRef.mIsTag = false;
             inlRef.mIsStash = true;
+        }
+        else if ( detached && ref == QLatin1Literal("< DETACHED >") ) {
+            inlRef.mRefName = tr("< DETACHED >");
+            inlRef.mIsBranch = false;
+            inlRef.mIsCurrent = false;
+            inlRef.mIsRemote = false;
+            inlRef.mIsTag = false;
+            inlRef.mIsStash = false;
         }
         else {
             // qDebug() << "HistoryModel::scanInlineReferences => Unhandled ref:" << ref;

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -228,6 +228,11 @@ void HistoryModel::afterAppend()
     endInsertRows();
 }
 
+/**
+ * @internal
+ * @see RM::EventInterface
+ */
+///@{
 
 void HistoryModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 {
@@ -238,6 +243,7 @@ void HistoryModel::onRefMoved(RM::Repo* repo, RM::Ref* ref)
 {
     scanInlineReferences();
 }
+///@}
 
 void HistoryModel::ensurePopulated( int row )
 {

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -319,8 +319,7 @@ void HistoryModel::scanInlineReferences()
     bool detached = mRepo.isHeadDetached();
     if ( detached ) {
         // append HEAD when detached
-        refs[QLatin1Literal("< DETACHED >")] =
-                refHEAD.resolveToObjectId( r );
+        refs[ QStringLiteral("< DETACHED >") ] = refHEAD.resolveToObjectId( r );
     }
 
     QElapsedTimer   stopwatch;
@@ -333,7 +332,7 @@ void HistoryModel::scanInlineReferences()
         HistoryInlineRef inlRef;
         inlRef.mIsDetached = detached;
 
-        if ( mDisplays.testFlag(DisplayLocals) && ref.startsWith(QLatin1Literal("refs/heads/")) ) {
+        if ( mDisplays.testFlag(DisplayLocals) && ref.startsWith(QStringLiteral("refs/heads/")) ) {
             inlRef.mRefName = ref.mid( strlen( "refs/heads/" ) );
             inlRef.mIsBranch = true;
             inlRef.mIsRemote = false;
@@ -341,7 +340,7 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsStash = false;
             inlRef.mIsCurrent = !detached ? (inlRef.mRefName == refHEAD.shorthand()) : false;
         }
-        else if (mDisplays.testFlag( DisplayTags ) && ref.startsWith( QLatin1Literal("refs/tags/") ) ) {
+        else if (mDisplays.testFlag( DisplayTags ) && ref.startsWith( QStringLiteral("refs/tags/") ) ) {
             inlRef.mRefName = ref.mid( strlen( "refs/tags/" ) );
             inlRef.mIsBranch = false;
             inlRef.mIsRemote = false;
@@ -350,9 +349,9 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsStash = false;
         }
         else if (mDisplays.testFlag(DisplayRemotes) &&
-                 ref.startsWith( QLatin1Literal("refs/remotes/")) ) {
+                 ref.startsWith( QStringLiteral("refs/remotes/")) ) {
 
-            if (ref.endsWith( QLatin1Literal("HEAD"))) {
+            if (ref.endsWith( QStringLiteral("HEAD"))) {
                 continue; // Skip "HEAD"
             }
             inlRef.mRefName = ref.mid( strlen( "refs/remotes/" ) );
@@ -362,7 +361,7 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsCurrent = false;
             inlRef.mIsStash = false;
         }
-        else if (ref == QLatin1Literal("refs/stash")) {
+        else if (ref == QStringLiteral("refs/stash")) {
             inlRef.mRefName = tr( "<recent stash>" );
             inlRef.mIsBranch = false;
             inlRef.mIsCurrent = true;
@@ -370,7 +369,7 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsTag = false;
             inlRef.mIsStash = true;
         }
-        else if ( detached && ref == QLatin1Literal("< DETACHED >") ) {
+        else if ( detached && ref == QStringLiteral("< DETACHED >") ) {
             inlRef.mRefName = tr("< DETACHED >");
             inlRef.mIsBranch = false;
             inlRef.mIsCurrent = false;

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -390,6 +390,8 @@ void HistoryModel::scanInlineReferences()
 
 void HistoryModel::updateInlineRefs(const QHash<Git::ObjectId, HistoryInlineRefs>& refsById)
 {
+    HistoryInlineRef_LessThan lt;
+
     for( int i = 0; i < mEntries.count(); i++ )
     {
         HistoryEntry* e = mEntries[i];
@@ -397,6 +399,9 @@ void HistoryModel::updateInlineRefs(const QHash<Git::ObjectId, HistoryInlineRefs
 
         HistoryInlineRefs newRefs = refsById.value( e->id() );
         HistoryInlineRefs oldRefs = e->refs();
+
+        // sort newRefs: no need to sort oldRefs as it is already sorted)
+        std::sort( newRefs.begin(), newRefs.end(), lt );
 
         if( oldRefs.count() != newRefs.count() )
         {

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -359,7 +359,7 @@ void HistoryModel::scanInlineReferences()
         else if (ref == QLatin1Literal("refs/stash")) {
             inlRef.mRefName = tr( "<recent stash>" );
             inlRef.mIsBranch = false;
-            inlRef.mIsCurrent = false;
+            inlRef.mIsCurrent = true;
             inlRef.mIsRemote = false;
             inlRef.mIsTag = false;
             inlRef.mIsStash = true;

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -34,6 +34,8 @@ HistoryModel::HistoryModel( const Git::Repository& repo, QObject* parent )
     : QAbstractTableModel( parent )
 {
     mRepo = repo;
+    Q_ASSERT( mRepo.isValid() );
+
     mMode = modeSimple;
     mShowRoots = ShowRootHeadOnly;
 
@@ -41,7 +43,6 @@ HistoryModel::HistoryModel( const Git::Repository& repo, QObject* parent )
 
     RM::RepoMan &rm = MacGitver::repoMan();
     connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
-    Q_ASSERT( mRepo.isValid() );
 }
 
 HistoryModel::~HistoryModel()

--- a/History/HistoryModel.cpp
+++ b/History/HistoryModel.cpp
@@ -327,7 +327,7 @@ void HistoryModel::scanInlineReferences()
             inlRef.mIsRemote = false;
             inlRef.mIsTag = false;
             inlRef.mIsStash = false;
-            inlRef.mIsCurrent = inlRef.mRefName == refHEAD.shorthand();
+            inlRef.mIsCurrent = !detached ? (inlRef.mRefName == refHEAD.shorthand()) : false;
         }
         else if (mDisplays.testFlag( DisplayTags ) && ref.startsWith( QLatin1Literal("refs/tags/") ) ) {
             inlRef.mRefName = ref.mid( strlen( "refs/tags/" ) );

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -115,6 +115,7 @@ private slots:
     void afterAppend();
 
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
+    void onRefDestroyed(RM::Repo* repo, RM::Ref* ref);
     void onRefMoved(RM::Repo*repo, RM::Ref*ref);
 
 private:

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -37,6 +37,7 @@ class HistoryModel : public QAbstractTableModel
 {
     friend class HistoryBuilder;
     Q_OBJECT
+
 public:
     enum Columns
     {
@@ -94,10 +95,10 @@ public:
 public:
     void setShowRoots( Roots roots );
     void changeDisplays(InlineRefDisplays displays, bool activate);
-    void append( HistoryEntry* entry );
     void buildHistory();
 
 private:
+    void append( HistoryEntry* entry );
     void updateRows( int firstRow, int lastRow );
     void scanInlineReferences();
 

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -25,14 +25,14 @@
 
 #include "libGitWrap/Repository.hpp"
 
+#include "HistoryEntry.h"
+
+
 namespace RM
 {
     class Ref;
     class Repo;
 }
-
-
-class HistoryEntry;
 
 class HistoryModel : public QAbstractTableModel
 {
@@ -102,6 +102,7 @@ private:
     void append( HistoryEntry* entry );
     void updateRows( int firstRow, int lastRow );
     void scanInlineReferences();
+    inline void updateInlineRefs(const QHash< Git::ObjectId, HistoryInlineRefs >& refsById);
 
 public slots:
     void ensurePopulated( int row );

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -121,6 +121,7 @@ private slots:
     ///@{
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
     void onRefLinkChanged(RM::Repo* repo, RM::Ref* ref);
+    void onRefMoved(RM::Repo*repo, RM::Ref*ref);
     ///@}
 
 private:

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -120,7 +120,6 @@ private slots:
      */
     ///@{
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
-    void onRefLinkChanged(RM::Repo* repo, RM::Ref* ref);
     void onRefMoved(RM::Repo*repo, RM::Ref*ref);
     ///@}
 

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -31,6 +31,7 @@ namespace RM
     class Repo;
 }
 
+
 class HistoryEntry;
 
 class HistoryModel : public QAbstractTableModel
@@ -111,8 +112,13 @@ private slots:
     void beforeAppend();
     void afterAppend();
 
-    // react on RepoMan signals
+    /**
+     * @internal
+     * @see RM::EventInterface
+     */
+    ///@{
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
+    ///@}
 
 private:
     InlineRefDisplays           mDisplays;

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -114,14 +114,8 @@ private slots:
     void beforeAppend();
     void afterAppend();
 
-    /**
-     * @internal
-     * @see RM::EventInterface
-     */
-    ///@{
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
     void onRefMoved(RM::Repo*repo, RM::Ref*ref);
-    ///@}
 
 private:
     InlineRefDisplays           mDisplays;

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -25,6 +25,12 @@
 
 #include "libGitWrap/Repository.hpp"
 
+namespace RM
+{
+    class Ref;
+    class Repo;
+}
+
 class HistoryEntry;
 
 class HistoryModel : public QAbstractTableModel
@@ -103,6 +109,9 @@ private slots:
     void afterClear();
     void beforeAppend();
     void afterAppend();
+
+    // react on RepoMan signals
+    void onRefCreated(RM::Repo* repo, RM::Ref* ref);
 
 private:
     InlineRefDisplays           mDisplays;

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -120,6 +120,7 @@ private slots:
      */
     ///@{
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
+    void onRefLinkChanged(RM::Repo* repo, RM::Ref* ref);
     ///@}
 
 private:

--- a/History/HistoryModel.h
+++ b/History/HistoryModel.h
@@ -101,6 +101,7 @@ public:
 private:
     void append( HistoryEntry* entry );
     void updateRows( int firstRow, int lastRow );
+
     void scanInlineReferences();
     inline void updateInlineRefs(const QHash< Git::ObjectId, HistoryInlineRefs >& refsById);
 

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -246,6 +246,9 @@ void BranchesModel::findInvalidRefItems(QVector<RefItem*>& invalidItems, RefItem
 ///@{
 void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 {
+    if ( repo != mData->repository() ) {
+        return;
+    }
     Git::Result r;
     Git::Reference gref = repo->gitRepo().reference( r, ref->fullName() );
     Q_ASSERT( r );
@@ -255,6 +258,10 @@ void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 
 void BranchesModel::onRefDestroyed(RM::Repo* repo, RM::Ref* ref)
 {
+    if ( repo != mData->repository() ) {
+        return;
+    }
+
     // TODO: This is an ugly workaround to find a matching RefItem!
     // We simply recursively search for invalid objects and delete them.
     QVector<RefItem*> invalidItems;
@@ -272,8 +279,11 @@ void BranchesModel::onRefDestroyed(RM::Repo* repo, RM::Ref* ref)
 
 void BranchesModel::onRefMoved(RM::Repo* repo, RM::Ref* ref)
 {
-    Q_UNUSED( repo )
     Q_UNUSED( ref )
+
+    if ( repo != mData->repository() ) {
+        return;
+    }
 
     // TODO: scan for changes in RefItems instead of performing a full update.
     QVector<int> updateRoles;

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -1,6 +1,6 @@
 /*
  * MacGitver
- * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ * Copyright (C) 2015 The MacGitver-Developers <dev@macgitver.org>
  *
  * (C) Sascha Cunz <sascha@macgitver.org>
  *

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -37,6 +37,7 @@ BranchesModel::BranchesModel( BranchesViewData* parent )
 {
     RM::RepoMan& rm = MacGitver::repoMan();
     connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
+    connect( &rm, SIGNAL(refMoved(RM::Repo*,RM::Ref*)), this, SLOT(onRefMoved(RM::Repo*,RM::Ref*)) );
 }
 
 BranchesModel::~BranchesModel()
@@ -294,6 +295,18 @@ void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
     Q_ASSERT( r );
 
     insertRef( true, gref );
+}
+
+void BranchesModel::onRefMoved(RM::Repo* repo, RM::Ref* ref)
+{
+    Q_UNUSED( repo )
+    Q_UNUSED( ref )
+
+    // TODO: scan for changes in RefItems instead of performing a full update.
+    QVector<int> updateRoles;
+    updateRoles << Qt::DisplayRole << Qt::BackgroundRole
+                << Qt::FontRole << Qt::DecorationRole;
+    emit dataChanged( index(0, 0), index( rowCount( QModelIndex() ) - 1, 0 ), updateRoles );
 }
 ///@}
 

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -266,46 +266,7 @@ void BranchesModel::rereadBranches()
             for( int i = 0; i < sl.count(); ++i )
             {
                 const Git::Reference &currentRef = sl[ i ];
-                RefScope* parentScope = NULL;
-                if ( currentRef.isLocal() )
-                    parentScope = scopeLocal;
-                else if ( currentRef.isRemote() )
-                    parentScope = scopeRemote;
-                else
-                    parentScope = scopeOther;
-
-                QStringList parts = currentRef.shorthand().split( QChar( L'/' ) );
-                if ( parts.count() == 1 )
-                {
-                    new RefBranch( parentScope, parts.last(), currentRef );
-                }
-                else
-                {
-                    RefItem* ns = parentScope;
-                    QString totPart;
-                    for( int j = 0; j < parts.count() - 1; j++ )
-                    {
-                        RefItem* next = NULL;
-                        QString partName = parts[ j ];
-                        totPart += partName + QChar( L'/' );
-                        foreach( RefItem* nsChild, ns->children )
-                        {
-                            if( nsChild->text() == partName ) // + Type
-                            {
-                                next = nsChild;
-                                break;
-                            }
-                        }
-                        if( !next )
-                        {
-                            next = new RefNameSpace( ns, partName );
-                        }
-                        ns = next;
-                    }
-
-                    Q_ASSERT( ns );
-                    new RefBranch( ns, parts.last(), currentRef );
-                }
+                insertRef( false, currentRef );
             }
         }
     }

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -165,6 +165,16 @@ bool BranchesModel::hasChildren( const QModelIndex& parent ) const
     return parentItem->children.count() > 0;
 }
 
+RefScope* BranchesModel::scopeForRef(const Git::Reference& ref) const
+{
+    RefItem* scope = NULL;
+    if ( ref.isLocal() )        scope = mRoot->children[0];
+    else if ( ref.isRemote() )  scope = mRoot->children[1];
+    else scope = mRoot->children[2];
+
+    return static_cast< RefScope* >( scope );
+}
+
 void BranchesModel::rereadBranches()
 {
     beginResetModel();

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -18,6 +18,10 @@
 
 #include <QFont>
 
+#include "libMacGitverCore/App/MacGitver.hpp"
+#include "libMacGitverCore/RepoMan/RepoMan.hpp"
+#include "libMacGitverCore/RepoMan/Ref.hpp"
+
 #include "libGitWrap/Result.hpp"
 #include "libGitWrap/Reference.hpp"
 
@@ -31,6 +35,8 @@ BranchesModel::BranchesModel( BranchesViewData* parent )
     , mData( parent )
     , mRoot( new RefItem )
 {
+    RM::RepoMan& rm = MacGitver::repoMan();
+    connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
 }
 
 BranchesModel::~BranchesModel()
@@ -271,6 +277,15 @@ void BranchesModel::rereadBranches()
     }
 
     endResetModel();
+}
+
+void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
+{
+    Git::Result r;
+    Git::Reference gref = repo->gitRepo().reference( r, ref->fullName() );
+    Q_ASSERT( r );
+
+    insertRef( true, gref );
 }
 
 QModelIndex BranchesModel::index(RefItem* item) const

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -247,9 +247,12 @@ void BranchesModel::rereadBranches()
 {
     beginResetModel();
 
-
     qDeleteAll( mRoot->children );
     mRoot->children.clear();
+
+    new RefScope( mRoot, tr( "Local" ) );
+    new RefScope( mRoot, tr( "Remote" ) );
+    new RefScope( mRoot, tr( "Tags" ) );
 
     Git::Repository repo = mData->repository();
 
@@ -259,10 +262,6 @@ void BranchesModel::rereadBranches()
         Git::ReferenceList sl = repo.allReferences( r );
         if( !sl.isEmpty() )
         {
-            RefScope* scopeLocal = new RefScope( mRoot, tr( "Local" ) );
-            RefScope* scopeRemote = new RefScope( mRoot, tr( "Remote" ) );
-            RefScope* scopeOther = new RefScope( mRoot, tr( "Tags" ) );
-
             for( int i = 0; i < sl.count(); ++i )
             {
                 const Git::Reference &currentRef = sl[ i ];

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -260,9 +260,13 @@ void BranchesModel::rereadBranches()
     new RefScope( mRoot, tr( "Remote" ) );
     new RefScope( mRoot, tr( "Tags" ) );
 
-    Git::Repository repo = mData->repository();
+    RM::Repo* repo = mData->repository();
+    Q_ASSERT( repo );
 
-    if( repo.isValid() )
+    // TODO: replace git repo with RM::Repo
+    Git::Repository gitRepo = repo ? repo->gitRepo() : Git::Repository();
+
+    if( gitRepo.isValid() )
     {
         Git::Result r;
         Git::ReferenceList sl = repo.allReferences( r );

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -302,24 +302,18 @@ void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 
 void BranchesModel::onRefDestroyed(RM::Repo* repo, RM::Ref* ref)
 {
-    if ( !ref ) {
-        return;
-    }
-
     // TODO: This is an ugly workaround to find a matching RefItem!
     // We simply recursively search for invalid objects and delete them.
     QVector<RefItem*> invalidItems;
     findInvalidRefItems( invalidItems, mRoot, ref );
 
-    if ( !invalidItems.isEmpty() ) {
-        while ( !invalidItems.isEmpty() ) {
-            RefItem* ri = invalidItems.takeFirst();
-            QModelIndex idx = index( ri );
-            beginRemoveRows( idx.parent(), idx.row(), idx.row() );
-            // RefItem unlinks itself from its parent
-            delete ri;
-            endRemoveRows();
-        }
+    while ( !invalidItems.isEmpty() ) {
+        RefItem* ri = invalidItems.takeFirst();
+        QModelIndex idx = index( ri );
+        beginRemoveRows( idx.parent(), idx.row(), idx.row() );
+        // RefItem unlinks itself from its parent
+        delete ri;
+        endRemoveRows();
     }
 }
 

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -232,7 +232,7 @@ void BranchesModel::insertBranch(const bool notify, RefItem* parent, const QStri
         beginInsertRows( index( parent ), row, row );
     }
 
-    new RefBranch( parent, name, ref );
+    new RefBranch( parent, ref );
 
     if (notify) {
         endInsertRows();

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -23,11 +23,8 @@
 #include "libMacGitverCore/RepoMan/Ref.hpp"
 
 #include "libGitWrap/Result.hpp"
-#include "libGitWrap/Reference.hpp"
 
 #include "BranchesModel.hpp"
-
-#include "RefItem.hpp"
 
 
 BranchesModel::BranchesModel( BranchesViewData* parent )
@@ -77,11 +74,6 @@ QVariant BranchesModel::data( const QModelIndex& index, int role ) const
     RefItem* item = static_cast< RefItem* >( index.internalPointer() );
     return item->data( index.column(), role );
 }
-
-
-
-
-
 
 Qt::ItemFlags BranchesModel::flags( const QModelIndex& index ) const
 {
@@ -161,7 +153,7 @@ void BranchesModel::insertRef(bool notify, const Git::Reference &ref)
     QStringList parts = ref.shorthand().split( QChar( L'/' ) );
     if ( parts.count() == 1 )
     {
-        insertBranch( notify, scope, parts.last(), ref );
+        insertBranch( notify, scope, ref );
         return;
     }
 
@@ -188,48 +180,9 @@ void BranchesModel::insertRef(bool notify, const Git::Reference &ref)
 
     Q_ASSERT( ns );
 
-    insertBranch( notify, ns, parts.last(), ref );
+    insertBranch( notify, ns, ref );
 }
 
-RefItem* BranchesModel::insertNamespace(const bool notify, RefItem* parent, const QString& name)
-{
-    RefItem* next = NULL;
-    if ( notify ) {
-        int fr = parent->children.count();
-        beginInsertRows( index( parent ), fr, fr );
-    }
-
-    next = new RefNameSpace( parent, name );
-
-    if ( notify ) {
-        endInsertRows();
-    }
-    return next;
-}
-
-void BranchesModel::insertBranch(const bool notify, RefItem* parent, const QString& name, const Git::Reference& ref)
-{
-    if ( notify ) {
-        int row = parent->children.count();
-        beginInsertRows( index( parent ), row, row );
-    }
-
-    new RefBranch( parent, ref );
-
-    if (notify) {
-        endInsertRows();
-    }
-}
-
-RefScope* BranchesModel::scopeForRef(const Git::Reference& ref) const
-{
-    RefItem* scope = NULL;
-    if ( ref.isLocal() )        scope = mRoot->children[0];
-    else if ( ref.isRemote() )  scope = mRoot->children[1];
-    else scope = mRoot->children[2];
-
-    return static_cast< RefScope* >( scope );
-}
 
 void BranchesModel::rereadBranches()
 {

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -265,6 +265,28 @@ void BranchesModel::rereadBranches()
 
 /**
  * @internal
+ *
+ * @brief   Workaround: temporary method to recursively destroy invalid tree items
+ *
+ * @param   item    the current item to check
+ *
+ * @param   ref     when given, the ref name will be compared with the RefItem
+ */
+void BranchesModel::findInvalidRefItems(QVector<RefItem*>& invalidItems, RefItem* item, const RM::Ref* ref )
+{
+    if ( !item->isValid() || item->sameReference( ref ) )
+    {
+        invalidItems << item;
+        return;
+    }
+
+    for ( int i = item->children.count() - 1; i > -1 ; i-- ) {
+        findInvalidRefItems( invalidItems, item->children[i], ref );
+    }
+}
+
+/**
+ * @internal
  * @see RM::EventInterface
  */
 ///@{

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -77,27 +77,10 @@ QVariant BranchesModel::data( const QModelIndex& index, int role ) const
     return item->data( index.column(), role );
 }
 
-bool BranchesModel::setData( const QModelIndex& index, const QVariant& value, int role )
-{
-    if ( !index.isValid() || (role != Qt::EditRole) )
-        return false;
 
-    RefItem *item = static_cast<RefItem *>( index.internalPointer() );
-    if ( !item )
-        return false;
 
-    Git::Result result;
-    if ( !item->setData( result, value, role, index.column() ) )
-    {
-        if( !result )
-            emit gitError( result );
 
-        return false;
-    }
 
-    emit dataChanged(index, index);
-    return true;
-}
 
 Qt::ItemFlags BranchesModel::flags( const QModelIndex& index ) const
 {

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -244,3 +244,14 @@ void BranchesModel::rereadBranches()
     endResetModel();
 }
 
+QModelIndex BranchesModel::index(RefItem* item) const
+{
+    if ( !item || (item == mRoot) )
+    {
+        return QModelIndex();
+    }
+
+    RefItem* parent = item->parent ? item->parent : mRoot;
+    int row = parent->children.indexOf( item );
+    return createIndex( row, 0, item );
+}

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -31,6 +31,9 @@ BranchesModel::BranchesModel( BranchesViewData* parent )
     : QAbstractItemModel( parent )
     , mData( parent )
     , mRoot( new RefItem )
+    , mHeaderLocal( NULL )
+    , mHeaderRemote( NULL )
+    , mHeaderTags( NULL )
 {
     RM::RepoMan& rm = MacGitver::repoMan();
     connect( &rm, SIGNAL(refCreated(RM::Repo*,RM::Ref*)), this, SLOT(onRefCreated(RM::Repo*,RM::Ref*)) );
@@ -191,9 +194,9 @@ void BranchesModel::rereadBranches()
     qDeleteAll( mRoot->children );
     mRoot->children.clear();
 
-    new RefScope( mRoot, tr( "Local" ) );
-    new RefScope( mRoot, tr( "Remote" ) );
-    new RefScope( mRoot, tr( "Tags" ) );
+    mHeaderLocal    = new RefScope( mRoot, tr( "Local" ) );
+    mHeaderRemote   = new RefScope( mRoot, tr( "Remote" ) );
+    mHeaderTags     = new RefScope( mRoot, tr( "Tags" ) );
 
     RM::Repo* repo = mData->repository();
 

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -306,8 +306,6 @@ void BranchesModel::onRefDestroyed(RM::Repo* repo, RM::Ref* ref)
         return;
     }
 
-    qDebug( "Reference will be deleted %s", qUtf8Printable(ref->name()) );
-
     // TODO: This is an ugly workaround to find a matching RefItem!
     // We simply recursively search for invalid objects and delete them.
     QVector<RefItem*> invalidItems;

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -247,10 +247,11 @@ void BranchesModel::rereadBranches()
 {
     beginResetModel();
 
-    Git::Repository repo = mData->repository();
 
     qDeleteAll( mRoot->children );
-    Q_ASSERT( mRoot->children.isEmpty() );
+    mRoot->children.clear();
+
+    Git::Repository repo = mData->repository();
 
     if( repo.isValid() )
     {

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -112,9 +112,6 @@ Qt::ItemFlags BranchesModel::flags( const QModelIndex& index ) const
     if ( (t == RefItem::Reference) || (t == RefItem::Namespace) )
         result |= Qt::ItemIsSelectable;
 
-    if ( item->isEditable() )
-        result |= Qt::ItemIsEditable;
-
     return result;
 }
 

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -282,6 +282,11 @@ void BranchesModel::rereadBranches()
     endResetModel();
 }
 
+/**
+ * @internal
+ * @see RM::EventInterface
+ */
+///@{
 void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 {
     Git::Result r;
@@ -290,6 +295,7 @@ void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
 
     insertRef( true, gref );
 }
+///@}
 
 QModelIndex BranchesModel::index(RefItem* item) const
 {

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -261,15 +261,14 @@ void BranchesModel::rereadBranches()
     new RefScope( mRoot, tr( "Tags" ) );
 
     RM::Repo* repo = mData->repository();
-    Q_ASSERT( repo );
 
-    // TODO: replace git repo with RM::Repo
+    // TODO: migrate to RM::Repo
     Git::Repository gitRepo = repo ? repo->gitRepo() : Git::Repository();
 
     if( gitRepo.isValid() )
     {
         Git::Result r;
-        Git::ReferenceList sl = repo.allReferences( r );
+        Git::ReferenceList sl = gitRepo.allReferences( r );
         if( !sl.isEmpty() )
         {
             for( int i = 0; i < sl.count(); ++i )

--- a/RefsViews/Branches/BranchesModel.cpp
+++ b/RefsViews/Branches/BranchesModel.cpp
@@ -242,11 +242,8 @@ void BranchesModel::onRefCreated(RM::Repo* repo, RM::Ref* ref)
     if ( repo != mData->repository() ) {
         return;
     }
-    Git::Result r;
-    Git::Reference gref = repo->gitRepo().reference( r, ref->fullName() );
-    Q_ASSERT( r );
 
-    insertRef( true, gref );
+    insertRef( true, ref );
 }
 
 void BranchesModel::onRefDestroyed(RM::Repo* repo, RM::Ref* ref)

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -1,6 +1,6 @@
 /*
  * MacGitver
- * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ * Copyright (C) 2015 The MacGitver-Developers <dev@macgitver.org>
  *
  * (C) Sascha Cunz <sascha@macgitver.org>
  *

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -26,6 +26,7 @@
 #include "Branches/BranchesViewData.hpp"
 
 class RefItem;
+class RefScope;
 
 class BranchesModel : public QAbstractItemModel
 {
@@ -49,6 +50,9 @@ public:
 
 signals:
     void gitError( const Git::Result& error );
+
+private:
+    inline RefScope* scopeForRef( const Git::Reference& ref ) const;
 
 private:
     BranchesViewData*   mData;

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -71,6 +71,9 @@ private:
 private:
     BranchesViewData*   mData;
     RefItem*            mRoot;
+
+private:
+    static void findInvalidRefItems(QVector<RefItem*>& invalidItems, RefItem* item, const RM::Ref* ref);
 };
 
 #endif

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -25,6 +25,12 @@
 
 #include "Branches/BranchesViewData.hpp"
 
+namespace RM
+{
+    class Ref;
+    class Repo;
+}
+
 class RefItem;
 class RefScope;
 
@@ -50,6 +56,15 @@ public:
 
 signals:
     void gitError( const Git::Result& error );
+
+private slots:
+    /**
+     * @internal
+     * @see RM::EventInterface
+     */
+    ///@{
+    void onRefCreated(RM::Repo* repo, RM::Ref* ref);
+    ///@}
 
 private:
     QModelIndex index(RefItem* item) const;

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -45,7 +45,6 @@ public:
     int rowCount( const QModelIndex& parent ) const;
     int columnCount( const QModelIndex& parent ) const;
     QVariant data( const QModelIndex& index, int role ) const;
-    bool setData( const QModelIndex& index, const QVariant& value, int role );
     Qt::ItemFlags flags( const QModelIndex& index ) const;
     QModelIndex index( int row, int column = 0, const QModelIndex& parent = QModelIndex() ) const;
     QModelIndex parent( const QModelIndex& child ) const;

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -59,6 +59,7 @@ signals:
 
 private slots:
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
+    void onRefMoved(RM::Repo* repo, RM::Ref* ref);
 
 private:
     QModelIndex index(RefItem* item) const;

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -54,6 +54,9 @@ signals:
 private:
     QModelIndex index(RefItem* item) const;
 
+    void insertRef(bool notify, const Git::Reference& ref);
+    inline RefItem* insertNamespace(const bool notify, RefItem* parent, const QString& name);
+    inline void insertBranch(const bool notify, RefItem *ns, const QString &name, const Git::Reference& ref);
     inline RefScope* scopeForRef( const Git::Reference& ref ) const;
 
 private:

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -58,6 +58,7 @@ signals:
 
 private slots:
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
+    void onRefDestroyed(RM::Repo* repo, RM::Ref* ref);
     void onRefMoved(RM::Repo* repo, RM::Ref* ref);
 
 private:

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -58,13 +58,7 @@ signals:
     void gitError( const Git::Result& error );
 
 private slots:
-    /**
-     * @internal
-     * @see RM::EventInterface
-     */
-    ///@{
     void onRefCreated(RM::Repo* repo, RM::Ref* ref);
-    ///@}
 
 private:
     QModelIndex index(RefItem* item) const;

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -52,6 +52,8 @@ signals:
     void gitError( const Git::Result& error );
 
 private:
+    QModelIndex index(RefItem* item) const;
+
     inline RefScope* scopeForRef( const Git::Reference& ref ) const;
 
 private:

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -100,9 +100,9 @@ private:
     inline RefScope* scopeForRef( const Git::Reference& ref ) const
     {
         RefItem* scope = NULL;
-        if ( ref.isLocal() )        scope = mRoot->children[0];
-        else if ( ref.isRemote() )  scope = mRoot->children[1];
-        else scope = mRoot->children[2];
+        if ( ref.isLocal() )        scope = mHeaderLocal;
+        else if ( ref.isRemote() )  scope = mHeaderRemote;
+        else scope = mHeaderTags;
 
         return static_cast< RefScope* >( scope );
     }
@@ -110,6 +110,10 @@ private:
 private:
     BranchesViewData*   mData;
     RefItem*            mRoot;
+
+    RefScope*           mHeaderLocal;
+    RefScope*           mHeaderRemote;
+    RefScope*           mHeaderTags;
 
 private:
     static void findInvalidRefItems(QVector<RefItem*>& invalidItems, RefItem* item, const RM::Ref* ref);

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -21,15 +21,13 @@
 
 #include <QAbstractItemModel>
 
-#include "libGitWrap/Reference.hpp"
-#include "libGitWrap/Repository.hpp"
+#include "libMacGitverCore/RepoMan/Ref.hpp"
 
 #include "Branches/BranchesViewData.hpp"
 #include "RefItem.hpp"
 
 namespace RM
 {
-    class Ref;
     class Repo;
 }
 
@@ -66,46 +64,11 @@ private slots:
 private:
     QModelIndex index(RefItem* item) const;
 
-    void insertRef(bool notify, const Git::Reference& ref);
-    inline RefItem* insertNamespace(const bool notify, RefItem* parent, const QString& name)
-    {
-        RefItem* next = NULL;
-        if ( notify ) {
-            int fr = parent->children.count();
-            beginInsertRows( index( parent ), fr, fr );
-        }
+    void insertRef(bool notify, const RM::Ref* ref);
 
-        next = new RefNameSpace( parent, name );
-
-        if ( notify ) {
-            endInsertRows();
-        }
-        return next;
-    }
-
-    inline void insertBranch(const bool notify, RefItem *parent, const Git::Reference& ref)
-    {
-        if ( notify ) {
-            int row = parent->children.count();
-            beginInsertRows( index( parent ), row, row );
-        }
-
-        new RefBranch( parent, ref );
-
-        if (notify) {
-            endInsertRows();
-        }
-    }
-
-    inline RefScope* scopeForRef( const Git::Reference& ref ) const
-    {
-        RefItem* scope = NULL;
-        if ( ref.isLocal() )        scope = mHeaderLocal;
-        else if ( ref.isRemote() )  scope = mHeaderRemote;
-        else scope = mHeaderTags;
-
-        return static_cast< RefScope* >( scope );
-    }
+    inline RefItem* insertNamespace(const bool notify, RefItem* parent, const QString& name);
+    inline void insertBranch(const bool notify, RefItem *parent, const RM::Ref* ref);
+    inline RefScope* scopeForRef( const RM::Ref* ref ) const;
 
 private:
     BranchesViewData*   mData;
@@ -118,5 +81,51 @@ private:
 private:
     static void findInvalidRefItems(QVector<RefItem*>& invalidItems, RefItem* item, const RM::Ref* ref);
 };
+
+
+// -- INLINED PRIVATE METHODS BEGIN --8>
+
+RefItem* BranchesModel::insertNamespace(const bool notify, RefItem* parent, const QString& name)
+{
+    RefItem* next = NULL;
+    if ( notify ) {
+        int fr = parent->children.count();
+        beginInsertRows( index( parent ), fr, fr );
+    }
+
+    next = new RefNameSpace( parent, name );
+
+    if ( notify ) {
+        endInsertRows();
+    }
+    return next;
+}
+
+void BranchesModel::insertBranch(const bool notify, RefItem* parent, const RM::Ref* ref)
+{
+    if ( notify ) {
+        int row = parent->children.count();
+        beginInsertRows( index( parent ), row, row );
+    }
+
+    new RefBranch( parent, ref );
+
+    if (notify) {
+        endInsertRows();
+    }
+}
+
+RefScope*BranchesModel::scopeForRef(const RM::Ref* ref) const
+{
+    RefItem* scope = NULL;
+    if ( ref->type() == RM::BranchType )        scope = mHeaderLocal;
+    // TODO: how to find the "remote branches"?
+    //    else if ( ref->isA<RM::RemoteObject>() )    scope = mHeaderRemote;
+    else scope = mHeaderTags;
+
+    return static_cast< RefScope* >( scope );
+}
+
+// <8-- INLINED PRIVATE METHODS END --
 
 #endif

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -70,9 +70,9 @@ private:
     void insertRefs(bool notify, const RM::CollectionNode* cn);
     void insertRefs(bool notify, const RM::RefTreeNode* ns);
 
-    inline RefItem* insertNamespace(bool notify, RefItem* parent, const QString& name);
-    inline void insertBranch(bool notify, RefItem *parent, const RM::Ref* ref);
-    inline RefScope* scopeForRef(Git::RefName refName) const;
+    RefItem* insertNamespace(bool notify, RefItem* parent, const QString& name);
+    void insertBranch(bool notify, RefItem *parent, const RM::Ref* ref);
+    RefScope* scopeForRef(Git::RefName refName) const;
 
 private:
     BranchesViewData*   mData;
@@ -89,7 +89,7 @@ private:
 
 // -- INLINED PRIVATE METHODS BEGIN --8>
 
-RefItem* BranchesModel::insertNamespace(bool notify, RefItem* parent, const QString& name)
+inline RefItem* BranchesModel::insertNamespace(bool notify, RefItem* parent, const QString& name)
 {
     RefItem* next = NULL;
     if ( notify ) {
@@ -105,7 +105,7 @@ RefItem* BranchesModel::insertNamespace(bool notify, RefItem* parent, const QStr
     return next;
 }
 
-void BranchesModel::insertBranch(bool notify, RefItem* parent, const RM::Ref* ref)
+inline void BranchesModel::insertBranch(bool notify, RefItem* parent, const RM::Ref* ref)
 {
     if ( notify ) {
         int row = parent->children.count();
@@ -119,7 +119,7 @@ void BranchesModel::insertBranch(bool notify, RefItem* parent, const RM::Ref* re
     }
 }
 
-RefScope* BranchesModel::scopeForRef(Git::RefName refName) const
+inline RefScope* BranchesModel::scopeForRef(Git::RefName refName) const
 {
     if ( refName.isBranch() ) {
         return refName.isRemote() ? mHeaderRemote : mHeaderLocal;

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -21,6 +21,8 @@
 
 #include <QAbstractItemModel>
 
+#include "libGitWrap/RefName.hpp"
+
 #include "libMacGitverCore/RepoMan/Ref.hpp"
 
 #include "Branches/BranchesViewData.hpp"
@@ -65,10 +67,12 @@ private:
     QModelIndex index(RefItem* item) const;
 
     void insertRef(bool notify, const RM::Ref* ref);
+    void insertRefs(bool notify, const RM::CollectionNode* cn);
+    void insertRefs(bool notify, const RM::RefTreeNode* ns);
 
     inline RefItem* insertNamespace(const bool notify, RefItem* parent, const QString& name);
     inline void insertBranch(const bool notify, RefItem *parent, const RM::Ref* ref);
-    inline RefScope* scopeForRef( const RM::Ref* ref ) const;
+    inline RefScope* scopeForRef(Git::RefName refName) const;
 
 private:
     BranchesViewData*   mData;
@@ -115,15 +119,14 @@ void BranchesModel::insertBranch(const bool notify, RefItem* parent, const RM::R
     }
 }
 
-RefScope*BranchesModel::scopeForRef(const RM::Ref* ref) const
+RefScope* BranchesModel::scopeForRef(Git::RefName refName) const
 {
-    RefItem* scope = NULL;
-    if ( ref->type() == RM::BranchType )        scope = mHeaderLocal;
-    // TODO: how to find the "remote branches"?
-    //    else if ( ref->isA<RM::RemoteObject>() )    scope = mHeaderRemote;
-    else scope = mHeaderTags;
+    if ( refName.isBranch() ) {
+        return refName.isRemote() ? mHeaderRemote : mHeaderLocal;
+    }
 
-    return static_cast< RefScope* >( scope );
+    // TODO: analyze scopes for all reference types
+    return mHeaderTags;
 }
 
 // <8-- INLINED PRIVATE METHODS END --

--- a/RefsViews/Branches/BranchesModel.hpp
+++ b/RefsViews/Branches/BranchesModel.hpp
@@ -70,8 +70,8 @@ private:
     void insertRefs(bool notify, const RM::CollectionNode* cn);
     void insertRefs(bool notify, const RM::RefTreeNode* ns);
 
-    inline RefItem* insertNamespace(const bool notify, RefItem* parent, const QString& name);
-    inline void insertBranch(const bool notify, RefItem *parent, const RM::Ref* ref);
+    inline RefItem* insertNamespace(bool notify, RefItem* parent, const QString& name);
+    inline void insertBranch(bool notify, RefItem *parent, const RM::Ref* ref);
     inline RefScope* scopeForRef(Git::RefName refName) const;
 
 private:
@@ -89,7 +89,7 @@ private:
 
 // -- INLINED PRIVATE METHODS BEGIN --8>
 
-RefItem* BranchesModel::insertNamespace(const bool notify, RefItem* parent, const QString& name)
+RefItem* BranchesModel::insertNamespace(bool notify, RefItem* parent, const QString& name)
 {
     RefItem* next = NULL;
     if ( notify ) {
@@ -105,7 +105,7 @@ RefItem* BranchesModel::insertNamespace(const bool notify, RefItem* parent, cons
     return next;
 }
 
-void BranchesModel::insertBranch(const bool notify, RefItem* parent, const RM::Ref* ref)
+void BranchesModel::insertBranch(bool notify, RefItem* parent, const RM::Ref* ref)
 {
     if ( notify ) {
         int row = parent->children.count();

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -264,6 +264,7 @@ void BranchesView::attachedToContext(BlueSky::ViewContext* ctx, BlueSky::ViewCon
              , this, SLOT(actionFailed(const Git::Result&)) );
 
     mTree->setModel( mData->mSortProxy );
+    mTree->expandAll();
 }
 
 void BranchesView::detachedFromContext(BlueSky::ViewContext* ctx )

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -145,9 +145,6 @@ void BranchesView::onRemoveRef()
                               .arg(branch->reference().shorthand())
                               .arg(r.errorText()) );
     }
-
-    // TODO: workaround to update the views
-    mData->mModel->rereadBranches();
 }
 
 bool BranchesView::checkRemoveRef( const Git::Reference& ref )

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -37,9 +37,9 @@
 
 BranchesView::BranchesView()
     : ContextView( "Branches" )
+    , mTree( new QTreeView )
     , mData( NULL )
 {
-    mTree = new QTreeView;
 #ifdef Q_OS_MACX
     mTree->setAttribute( Qt::WA_MacShowFocusRect, false );
 #endif

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -261,8 +261,8 @@ void BranchesView::attachedToContext(BlueSky::ViewContext* ctx, BlueSky::ViewCon
     delete mData;
     mData = myData;
 
-    connect( mData->mModel, SIGNAL(gitError(const Git::Result&))
-             , this, SLOT(actionFailed(const Git::Result&)) );
+    connect( mData->mModel, SIGNAL(gitError(const Git::Result&)),
+             this, SLOT(actionFailed(const Git::Result&)) );
 
     mTree->setModel( mData->mSortProxy );
     mTree->expandAll();

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -115,9 +115,6 @@ void BranchesView::onCheckoutRef()
                               .arg(branch->reference().shorthand())
                               .arg(r.errorText()) );
     }
-
-    // TODO: workaround to update the views
-    update();
 }
 
 void BranchesView::onRemoveRef()

--- a/RefsViews/Branches/BranchesView.cpp
+++ b/RefsViews/Branches/BranchesView.cpp
@@ -47,6 +47,7 @@ BranchesView::BranchesView()
     mTree->setIndentation( 12 );
     mTree->setHeaderHidden( true );
     mTree->setRootIsDecorated( false );
+    mTree->setItemDelegate( &mRefDelegate );
 
     setupActions( this );
 

--- a/RefsViews/Branches/BranchesView.hpp
+++ b/RefsViews/Branches/BranchesView.hpp
@@ -19,12 +19,12 @@
 #ifndef MGV_BRANCHES_VIEW_HPP
 #define MGV_BRANCHES_VIEW_HPP
 
+#include "hic_BranchesViewActions.h"
+
 #include "libBlueSky/Contexts.hpp"
 
 class QTreeView;
 class QModelIndex;
-
-#include "hic_BranchesViewActions.h"
 
 namespace Git
 {

--- a/RefsViews/Branches/BranchesView.hpp
+++ b/RefsViews/Branches/BranchesView.hpp
@@ -54,8 +54,6 @@ public slots:
     void onRemoveRef();
     void onRenameRef();
 
-    void onJumpToCurrentBranch();
-
     void actionFailed(const Git::Result &error);
 
 protected:

--- a/RefsViews/Branches/BranchesView.hpp
+++ b/RefsViews/Branches/BranchesView.hpp
@@ -23,6 +23,8 @@
 
 #include "libBlueSky/Contexts.hpp"
 
+#include "RefsViewDelegate.h"
+
 class QTreeView;
 class QModelIndex;
 
@@ -31,6 +33,7 @@ namespace Git
     class Reference;
     class Result;
 }
+
 
 class BranchesViewData;
 
@@ -67,6 +70,7 @@ private:
     inline bool checkRemoveRef(const Git::Reference &ref);
 
 private:
+    RefsViewDelegate    mRefDelegate;
     QTreeView*          mTree;
     BranchesViewData*   mData;
 };

--- a/RefsViews/Branches/BranchesViewData.cpp
+++ b/RefsViews/Branches/BranchesViewData.cpp
@@ -56,16 +56,9 @@ void BranchesViewData::detachedFromContext()
     mModel = NULL;
 }
 
-Git::Repository BranchesViewData::repository() const
+RM::Repo* BranchesViewData::repository() const
 {
     IRepositoryContext* ctx = qobject_cast< IRepositoryContext* >( attachedContext() );
-
-    if( !ctx )
-    {
-        return Git::Repository();
-    }
-
-    RM::Repo* repo = ctx->repository();
-    return repo ? repo->gitRepo() : Git::Repository();
+    return ctx ? ctx->repository() : NULL;
 }
 

--- a/RefsViews/Branches/BranchesViewData.hpp
+++ b/RefsViews/Branches/BranchesViewData.hpp
@@ -26,6 +26,12 @@
 class BranchesModel;
 class RefsSortProxy;
 
+namespace RM
+{
+    class Repo;
+}
+
+
 class BranchesViewData : public BlueSky::ViewContextData
 {
     Q_OBJECT
@@ -37,7 +43,7 @@ private:
     void detachedFromContext();
 
 public:
-    Git::Repository repository() const;
+    RM::Repo* repository() const;
 
 public:
     BranchesModel*  mModel;

--- a/RefsViews/CMakeLists.txt
+++ b/RefsViews/CMakeLists.txt
@@ -15,6 +15,7 @@ SET( SRC_FILES
     RefItem.cpp
     RefRenameDialog.cpp
     RefsSortProxy.cpp
+    RefsViewDelegate.cpp
 
     Branches/BranchesModel.cpp
     Branches/BranchesView.cpp
@@ -28,6 +29,7 @@ SET( HDR_FILES
     RefItem.hpp
     RefRenameDialog.hpp
     RefsSortProxy.hpp
+    RefsViewDelegate.h
 
     Branches/BranchesModel.hpp
     Branches/BranchesView.hpp

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -66,13 +66,6 @@ QVariant RefItem::data(int col, int role) const
     return QVariant();
 }
 
-bool RefItem::setData(Git::Result& result, const QVariant &value, int role, int col)
-{
-    Q_UNUSED( value );
-    Q_UNUSED( role );
-    Q_UNUSED( col );
-    return false;
-}
 
 QString RefItem::text() const
 {
@@ -199,17 +192,5 @@ QVariant RefBranch::data(int col, int role) const
     return QVariant();
 }
 
-bool RefBranch::setData(Git::Result& result, const QVariant &value, int role, int col)
-{
-    if ( col == 0 )
-    {
-        QString newName = value.toString();
-        if ( newName.isEmpty() || (newName == mRef.name()) )
-            return false;
 
-        mRef.rename( result, newName );
-        return result;
-    }
 
-    return false;
-}

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -125,7 +125,7 @@ QVariant RefNameSpace::data(int col, int role) const
 }
 
 
-RefBranch::RefBranch(RefItem *p, const QString &t, const Git::Reference &ref)
+RefBranch::RefBranch(RefItem *p, const Git::Reference &ref)
     : RefItem( p )
     , mRef( ref )
 {

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -67,11 +67,6 @@ QString RefItem::text() const
     return QString();
 }
 
-bool RefItem::isEditable() const
-{
-    return false;
-}
-
 
 RefScope::RefScope(RefItem *p, const QString &t)
     : RefItem( p )

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -31,7 +31,6 @@ RefItem::RefItem()
 {
 }
 
-
 RefItem::RefItem(RefItem *p)
     : parent( p )
 {

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -86,11 +86,8 @@ QVariant RefScope::data(int col, int role) const
     case Qt::DisplayRole:
         return mText;
 
-    case Qt::BackgroundRole:
-        QLinearGradient g( 0, 0, 100, 0 );
-        g.setColorAt( 0.0, QColor(0, 0, 0, 0) );
-        g.setColorAt( 1.0, QColor(216, 233, 255) );
-        return QBrush( g );
+    case RefItem::RowBgRole:
+        return QColor(216, 233, 255);
     }
 
     if ( role == RefItem::TypeRole )

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -22,6 +22,8 @@
 #include "libGitWrap/Repository.hpp"
 #include "libGitWrap/Result.hpp"
 
+#include "libMacGitverCore/RepoMan/Ref.hpp"
+
 #include <QFont>
 #include <QLinearGradient>
 #include <QFileIconProvider>
@@ -45,6 +47,16 @@ RefItem::~RefItem()
         parent->children.removeOne( this );
     }
     qDeleteAll( children );
+}
+
+/**
+ * @brief   Checks the validity of internal data.
+ *
+ * @return  the default implementation returns always true
+ */
+bool RefItem::isValid() const
+{
+    return true;
 }
 
 QVariant RefItem::data(int col, int role) const
@@ -124,6 +136,30 @@ RefBranch::RefBranch(RefItem *p, const Git::Reference &ref)
     : RefItem( p )
     , mRef( ref )
 {
+}
+
+/**
+ * @brief   Am I pointing to a valid Git::Reference object?
+ *
+ * @return  true, if the owned reference is valid; false otherwise
+ */
+bool RefBranch::isValid() const
+{
+    return (mRef.isValid() && !mRef.wasDestroyed());
+}
+
+/**
+ * @brief   Workaround to compare the reference name.
+ *
+ *          This method will be deleted when migrating to RM::RepoMan.
+ *
+ * @param   ref the RM::Ref to compare with
+ *
+ * @return  true when both names match; false otherwise
+ */
+bool RefBranch::sameReference(const RM::Ref* ref) const
+{
+    return ref && mRef.name() == ref->fullName();
 }
 
 QVariant RefBranch::data(int col, int role) const

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -149,24 +149,16 @@ QVariant RefBranch::data(int col, int role) const
         }
     }
 
-    else if ( role == Qt::BackgroundRole )
+    else if ( role == RefItem::RowBgGradientRole )
     {
         Git::Result r;
-        if ( mRef.isCurrentBranch() )
+
+        if ( mRef.compare( mRef.repository().HEAD(r) ) == 0 )
         {
-            QLinearGradient g( 0, 0, 0, 30 );
-            g.setColorAt( 0.0, QColor(255, 255, 255, 0) );
-            g.setColorAt( 0.5, QColor(255, 181, 79) );
-            g.setColorAt( 1.0, QColor(255, 255, 255, 0) );
-            return QBrush(g);
-        }
-        else if ( mRef.compare( mRef.repository().HEAD(r) ) == 0 )
-        {
-            QLinearGradient g( 0, 0, 0, 30 );
-            g.setColorAt( 0.0, QColor(255, 255, 255, 0) );
-            g.setColorAt( 0.5, QColor(255, 181, 79).lighter() );
-            g.setColorAt( 1.0, QColor(255, 255, 255, 0) );
-            return QBrush(g);
+            QColor back = mRef.isCurrentBranch()
+                          ? QColor::fromHsl(35, 255, 190)
+                          : QColor::fromHsl(35, 255, 190).lighter(130);
+            return back;
         }
     }
 

--- a/RefsViews/RefItem.cpp
+++ b/RefsViews/RefItem.cpp
@@ -26,6 +26,9 @@
 #include <QFont>
 #include <QFileIconProvider>
 
+
+// -- RefItem --8>
+
 RefItem::RefItem()
     : parent( NULL )
 {
@@ -64,7 +67,6 @@ QVariant RefItem::data(int col, int role) const
     return QVariant();
 }
 
-
 QString RefItem::text() const
 {
     return QString();
@@ -100,6 +102,8 @@ QString RefScope::text() const
 }
 
 
+// -- RefNameSpace --8>
+
 RefNameSpace::RefNameSpace(RefItem *p, const QString &t)
     : RefScope( p, t )
 {
@@ -121,6 +125,9 @@ QVariant RefNameSpace::data(int col, int role) const
 
     return QVariant();
 }
+
+
+// -- RefBranch --8>
 
 RefBranch::RefBranch(RefItem* p, const RM::Ref* refInfo)
     : RefItem( p )

--- a/RefsViews/RefItem.hpp
+++ b/RefsViews/RefItem.hpp
@@ -24,6 +24,11 @@
 #include <QList>
 #include <QVariant>
 
+namespace RM
+{
+    class Ref;
+}
+
 
 class RefItem
 {
@@ -46,6 +51,10 @@ public:
     RefItem();
     RefItem( RefItem* p );
     virtual ~RefItem();
+
+public:
+    virtual bool isValid() const;
+    virtual bool sameReference(const RM::Ref* ref) const { return false; }
 
 public:
     RefItem* parent;
@@ -84,6 +93,10 @@ class RefBranch : public RefItem
 {
 public:
     explicit RefBranch(RefItem* p, const Git::Reference &ref);
+
+public:
+    bool isValid() const;
+    bool sameReference(const RM::Ref* ref) const;
 
     QVariant data( int col, int role ) const;
     bool setData(Git::Result& result, const QVariant &value, int role, int col);

--- a/RefsViews/RefItem.hpp
+++ b/RefsViews/RefItem.hpp
@@ -30,7 +30,9 @@ class RefItem
 public:
     enum Role
     {
-        TypeRole = Qt::UserRole
+        TypeRole = Qt::UserRole,
+        RowBgRole = Qt::UserRole + 1,
+        RowBgGradientRole = Qt::UserRole + 2
     };
 
     enum ItemType

--- a/RefsViews/RefItem.hpp
+++ b/RefsViews/RefItem.hpp
@@ -54,8 +54,6 @@ public:
     virtual QVariant data( int col, int role ) const;
     virtual bool setData(Git::Result &result, const QVariant &value, int role, int col );
     virtual QString text() const;
-
-    virtual bool isEditable() const;
 };
 
 

--- a/RefsViews/RefItem.hpp
+++ b/RefsViews/RefItem.hpp
@@ -85,7 +85,7 @@ public:
 class RefBranch : public RefItem
 {
 public:
-    RefBranch( RefItem* p, const QString& t, const Git::Reference &ref );
+    explicit RefBranch(RefItem* p, const Git::Reference &ref);
 
     QVariant data( int col, int role ) const;
     bool setData(Git::Result& result, const QVariant &value, int role, int col);

--- a/RefsViews/RefItem.hpp
+++ b/RefsViews/RefItem.hpp
@@ -61,7 +61,6 @@ public:
     QList< RefItem* > children;
 
     virtual QVariant data( int col, int role ) const;
-    virtual bool setData(Git::Result &result, const QVariant &value, int role, int col );
     virtual QString text() const;
 };
 
@@ -99,7 +98,6 @@ public:
     bool sameReference(const RM::Ref* ref) const;
 
     QVariant data( int col, int role ) const;
-    bool setData(Git::Result& result, const QVariant &value, int role, int col);
 
     Git::Reference reference() const
     {

--- a/RefsViews/RefItem.hpp
+++ b/RefsViews/RefItem.hpp
@@ -91,7 +91,10 @@ public:
 class RefBranch : public RefItem
 {
 public:
-    explicit RefBranch(RefItem* p, const Git::Reference &ref);
+    RefBranch(RefItem* p, const RM::Ref* refInfo);
+
+public:
+    static Git::Reference lookupGitReference( const RefBranch* item );
 
 public:
     bool isValid() const;
@@ -99,13 +102,13 @@ public:
 
     QVariant data( int col, int role ) const;
 
-    Git::Reference reference() const
-    {
-        return mRef;
-    }
+    const RM::Ref* referenceInfo() const;
 
 private:
-    Git::Reference  mRef;
+    const RM::Ref*  mRefInfo;
+
+private:
+    static Git::Reference lookupHEAD(Git::Result& result, const RM::Ref* ref);
 };
 
 #endif // REF_ITEM_HPP

--- a/RefsViews/RefRenameDialog.cpp
+++ b/RefsViews/RefRenameDialog.cpp
@@ -22,6 +22,9 @@
 
 #include "libGitWrap/Reference.hpp"
 
+#include "libMacGitverCore/RepoMan/Ref.hpp"
+
+
 RefRenameDialog::RefRenameDialog()
     : BlueSky::Dialog()
     , mRefInfo( 0 )
@@ -53,7 +56,7 @@ void RefRenameDialog::accept()
         return;
     }
 
-    Git::Reference ref = mRefInfo->reference();
+    Git::Reference ref = RefBranch::lookupGitReference( mRefInfo );
     const QString oldRefName = ref.name();
     const QString prefix = oldRefName.left( oldRefName.length() - ref.shorthand().length() );
 
@@ -73,7 +76,7 @@ void RefRenameDialog::updateValues()
 {
     if ( !mRefInfo ) return;
 
-    const Git::Reference& ref = mRefInfo->reference();
-    Q_ASSERT( ref.isValid() );
-    textRefName->setText( ref.shorthand() );
+    const RM::Ref* ref = mRefInfo->referenceInfo();
+    Q_ASSERT( ref );
+    textRefName->setText( ref->name() );
 }

--- a/RefsViews/RefsViewDelegate.cpp
+++ b/RefsViews/RefsViewDelegate.cpp
@@ -1,0 +1,47 @@
+#include "RefsViewDelegate.h"
+
+#include "RefItem.hpp"
+
+#include <QPainter>
+
+
+RefsViewDelegate::RefsViewDelegate(QObject* parent)
+    : QStyledItemDelegate( parent )
+{
+
+}
+
+RefsViewDelegate::~RefsViewDelegate()
+{
+
+}
+
+void RefsViewDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    const QRect rowRect = option.rect.adjusted( -(option.rect.left()), 0, 0, 0 );
+    const QVariant rowBg        = index.data( RefItem::RowBgRole );
+    const QVariant rowGradient  = index.data( RefItem::RowBgGradientRole );
+
+    if ( rowGradient.isValid() )
+    {
+        QColor back = rowGradient.value<QColor>();
+        QColor back2 = back.lighter(135);
+
+        const qreal wLimit = qreal( qMin(30, rowRect.width()) ) / qreal( qMax(30, rowRect.width()) );
+        QLinearGradient gradient( 0, 0, rowRect.width(), 0 );
+        gradient.setColorAt( 0.0, back2 );
+        gradient.setColorAt( wLimit, back );
+        gradient.setColorAt( 1.0 - wLimit, back );
+        gradient.setColorAt( 1.0, back2 );
+
+        painter->fillRect( rowRect, gradient );
+    }
+
+    else if ( rowBg.isValid() )
+    {
+        painter->fillRect( rowRect, rowBg.value<QBrush>() );
+    }
+
+    QStyledItemDelegate::paint( painter, option, index );
+}
+

--- a/RefsViews/RefsViewDelegate.h
+++ b/RefsViews/RefsViewDelegate.h
@@ -1,0 +1,17 @@
+#ifndef REFSVIEWDELEGATE_H
+#define REFSVIEWDELEGATE_H
+
+#include <QStyledItemDelegate>
+
+
+class RefsViewDelegate : public QStyledItemDelegate
+{
+public:
+    RefsViewDelegate( QObject* parent = 0 );
+    ~RefsViewDelegate();
+
+public:
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+};
+
+#endif

--- a/RepoManLogger/Listener.cpp
+++ b/RepoManLogger/Listener.cpp
@@ -102,10 +102,6 @@ void Listener::refMoved(RM::Repo* repo, RM::Ref* ref)
 {
 }
 
-void Listener::refLinkChanged(RM::Repo* repo, RM::Ref* ref)
-{
-}
-
 void Listener::refHeadDetached(RM::Repo* repo, RM::Ref* ref)
 {
 }

--- a/RepoManLogger/Listener.hpp
+++ b/RepoManLogger/Listener.hpp
@@ -47,7 +47,6 @@ public:
     void refCreated(RM::Repo* repo, RM::Ref* ref);
     void refAboutToBeDeleted(RM::Repo* repo, RM::Ref* ref);
     void refMoved(RM::Repo* repo, RM::Ref* ref);
-    void refLinkChanged(RM::Repo* repo, RM::Ref* ref);
     void refHeadDetached(RM::Repo* repo, RM::Ref* ref);
     void tagCreated(RM::Repo* repo, RM::Tag* tag);
     void tagAboutToBeDeleted(RM::Repo* repo, RM::Tag* tag);

--- a/Repository/CreateRepositoryDlg.cpp
+++ b/Repository/CreateRepositoryDlg.cpp
@@ -88,7 +88,7 @@ void CreateRepositoryDlg::accept()
     QString fn = QDir::toNativeSeparators( txtPath->text() );
     bool makeBare = chkMakeBare->isChecked() && chkMakeBare->isEnabled();
     Git::Result r;
-    Git::Repository repo = Git::Repository::create( fn, makeBare, r );
+    Git::Repository repo = Git::Repository::create( r, fn, makeBare );
 
     if( !r || !repo.isValid() )
     {

--- a/Repository/ProgressDlg.cpp
+++ b/Repository/ProgressDlg.cpp
@@ -34,17 +34,17 @@ void ProgressDlg::setAction( const QString& action,
 
     foreach( QString s, done )
     {
-        act += QLatin1Literal( " (<font color=\"green\">" ) % s % QLatin1Literal( "</font>)" );
+        act += QStringLiteral( " (<font color=\"green\">" ) % s % QStringLiteral( "</font>)" );
     }
 
     foreach( QString s, current )
     {
-        act += QLatin1Literal( " (<font color=\"blue\">" ) % s % QLatin1Literal( "</font>)" );
+        act += QStringLiteral( " (<font color=\"blue\">" ) % s % QStringLiteral( "</font>)" );
     }
 
     foreach( QString s, open )
     {
-        act += QLatin1Literal( " (<font color=\"red\">" ) % s % QLatin1Literal( "</font>)" );
+        act += QStringLiteral( " (<font color=\"red\">" ) % s % QStringLiteral( "</font>)" );
     }
 
     lblAction->setText( act );
@@ -79,15 +79,15 @@ void ProgressDlg::transportProgress( quint32 totalObjects,
     QString recv;
     if( receivedBytes > 1024 * 1024 * 950 ) /* 950 is so we get 0.9 gb */
     {
-        recv = QString::number( receivedBytes / (1024*1024*1024.0), 'f', 2 ) % QLatin1Literal( " Gb" );
+        recv = QString::number( receivedBytes / (1024*1024*1024.0), 'f', 2 ) % QStringLiteral( " Gb" );
     }
     else if( receivedBytes > 1024 * 950 )
     {
-        recv = QString::number( receivedBytes / (1024*1024.0), 'f', 2 ) % QLatin1Literal( " Mb" );
+        recv = QString::number( receivedBytes / (1024*1024.0), 'f', 2 ) % QStringLiteral( " Mb" );
     }
     else if( receivedBytes > 950 )
     {
-        recv = QString::number( receivedBytes / 1024.0, 'f', 2 ) % QLatin1Literal( " Kb" );
+        recv = QString::number( receivedBytes / 1024.0, 'f', 2 ) % QStringLiteral( " Kb" );
     }
     else
     {
@@ -130,7 +130,7 @@ void ProgressDlg::remoteMessage( const QString& msg )
     if( outBufLen )
         output += QString( outputBuffer, outBufLen );
 
-    QString log = mBaseLog % QLatin1Literal( "<br/>" ) %
+    QString log = mBaseLog % QStringLiteral( "<br/>" ) %
             output.replace( QChar( L'\n' ), QLatin1String("<br/>") ).simplified();
 
     txtLog->setHtml( log );
@@ -144,7 +144,7 @@ void ProgressDlg::beginStep( const QString& step )
 
 void ProgressDlg::finalizeStep()
 {
-    mBaseLog = txtLog->toHtml() % QLatin1Literal( "<br/>" );
+    mBaseLog = txtLog->toHtml() % QStringLiteral( "<br/>" );
     mRawRemoteMessage = QString();
 
     txtLog->setHtml( mBaseLog );

--- a/Repository/RepositoryContext.cpp
+++ b/Repository/RepositoryContext.cpp
@@ -28,7 +28,7 @@ void RepositoryContext::setRepository(RM::Repo* repo)
     mRepo = repo;
 }
 
-RM::Repo* RepositoryContext::repository()
+RM::Repo* RepositoryContext::repository() const
 {
     return mRepo;
 }

--- a/Repository/RepositoryContext.hpp
+++ b/Repository/RepositoryContext.hpp
@@ -33,7 +33,7 @@ public:
 
 public:
     void setRepository(RM::Repo* repo);
-    RM::Repo* repository();
+    RM::Repo* repository() const;
 
 private:
     RM::Repo*       mRepo;

--- a/WorkingTree/CommitDialog.cpp
+++ b/WorkingTree/CommitDialog.cpp
@@ -85,8 +85,8 @@ void CommitDialog::onCommit()
 
     if ( !r )
     {
-        QMessageBox::information( this, trUtf8("Failed to commit"),
-                                  trUtf8("Failed to commit. Git message:\n%1").arg(r.errorText()));
+        QMessageBox::warning( this, tr("Failed to commit"),
+                              tr("Failed to commit. Git message:\n%1").arg(r.errorText()));
     }
 }
 


### PR DESCRIPTION
The member `RefBranch->mRef` was a `Git::Reference` before. This is replaced now completely with a simple pointer to the valid `RM::Ref`. To avoid confusion I renamed the member to `mRefInfo`.

Known Bugs, that should be fixed, before the this PR is merged:
- [ ] Remote branches are missing in the tree
- [x] Scoped Branches are not shown.
- [ ] HEAD refs are not marked "orange" in submodules.
- [x] the prefixes "refs/heads", "refs/tags", ... should be hidden
- [ ] Regression: By accident, the reference name in the `Rename-Dialog` is initialized with the "pure" reference name, which is is wrong!

Here's a visual example, of how that currently looks:
![mgv-migrate-refitem](https://cloud.githubusercontent.com/assets/440517/6133017/2da6c360-b157-11e4-99e3-4bf9abaf437b.png)
