### PR TITLE
ngf/refsview

### DIFF
--- a/RefsViews/Branches/RefItem.cpp
+++ b/RefsViews/Branches/RefItem.cpp
@@ -133,6 +133,15 @@ RefItem::ItemType RefBranch::type() const
     return Branch;
 }
 
+bool RefBranch::isCurrentBranch(const RM::Ref* HEAD) const
+{
+    if ( HEAD ) {
+        return mObject->fullName() == HEAD->symbolicTarget();
+    }
+
+    return false;
+}
+
 QVariant RefBranch::data(int role) const
 {
     Git::Result r;
@@ -140,28 +149,27 @@ QVariant RefBranch::data(int role) const
 
     switch (role) {
     case Qt::FontRole:
-        #if 0
-        if( mRef.isCurrentBranch() )
+        if( isCurrentBranch( mObject->repository()->HEAD() ) )
         {
             QFont f;
             f.setBold( true );
             return f;
         }
-        #endif
         break;
 
     case RefItem::RowBgGradientRole:
-        #if 0
-        if ( mRef.compare( mRef.repository().HEAD(r) ) == 0 )
-        {
-            QColor back = mRef.isCurrentBranch()
-                          ? QColor::fromHsl(35, 255, 190)
-                          : QColor::fromHsl(35, 255, 190).lighter(130);
-            return back;
+    {
+        RM::Ref* HEAD = mObject->repository()->HEAD();
+        if ( isCurrentBranch( HEAD ) ) {
+            return QColor::fromHsl(35, 255, 190);
         }
-        #endif
+
+        if ( matchesHEAD( HEAD ) ) {
+            return QColor::fromHsl(35, 255, 190).lighter(130);
+        }
+
         break;
-    }
+    } }
 
     return RefItemObject::data(role);
 }

--- a/RefsViews/Branches/RefItem.hpp
+++ b/RefsViews/Branches/RefItem.hpp
@@ -27,6 +27,7 @@
 #include "libMacGitverCore/RepoMan/Branch.hpp"
 #include "libMacGitverCore/RepoMan/Tag.hpp"
 #include "libMacGitverCore/RepoMan/Remote.hpp"
+#include "libMacGitverCore/RepoMan/Repo.hpp"
 
 #include <QList>
 #include <QVariant>
@@ -148,6 +149,16 @@ public:
     }
 
 protected:
+    bool matchesHEAD(RM::Ref* HEAD) const
+    {
+        if ( HEAD ) {
+            return mObject->id() == HEAD->resolvedId();
+        }
+
+        return false;
+    }
+
+protected:
     T* mObject;
 };
 
@@ -205,6 +216,8 @@ public:
 public:
     QVariant data(int role) const;
     ItemType type() const;
+
+    bool isCurrentBranch(const RM::Ref* HEAD) const;
 };
 
 


### PR DESCRIPTION
To complete:
- [ ] "focusable" and "selectable" flags are switched for "headline" and "scope" items
- [ ] no context menu on tags

I let the image speak for itself (icons not included) :star::
![mgv-refsview-icons](https://cloud.githubusercontent.com/assets/440517/6198748/0fb8191e-b416-11e4-9b8b-c5e68dd69a15.png)
