### PR TITLE
fetch remotes of a repository 

### DIFF
--- a/Repository/RepoTreeView.cpp
+++ b/Repository/RepoTreeView.cpp
@@ -143,6 +143,11 @@ void RepoTreeView::onRepoDeactivated(RM::Repo* repo)
     }
 }
 
+
+void RepoTreeView::onCtxFetchAll()
+{
+}
+
 BlueSky::ViewContext* RepoTreeView::createContextObject() const
 {
     return new RepositoryContext;

--- a/Repository/RepoTreeView.cpp
+++ b/Repository/RepoTreeView.cpp
@@ -195,8 +195,7 @@ void RepoTreeView::onCtxFetchAll()
 
         foreach (const QString& alias, aliases) {
             Git::FetchOperation* op = new Git::FetchOperation( repo->gitRepo() );
-            // TODO: needs extension in GW-API
-            //op->setRemoteAlias( alias );
+            op->setRemoteAlias( alias );
             op->setBackgroundMode( true );
             connect( op, SIGNAL(finished()), this, SLOT(fetchOperationFinished()) );
             // TODO: create a central dialog to show progress of parallel operations

--- a/Repository/RepoTreeView.cpp
+++ b/Repository/RepoTreeView.cpp
@@ -147,7 +147,7 @@ void RepoTreeView::onRepoDeactivated(RM::Repo* repo)
 }
 
 /**
- * @brief Called as soon as one fetch operation finishes.
+ * @brief This slot is called, when a single fetch operation finishes.
  */
 void RepoTreeView::fetchOperationFinished()
 {

--- a/Repository/RepoTreeView.hpp
+++ b/Repository/RepoTreeView.hpp
@@ -55,6 +55,9 @@ private slots:  // for MacGitver::repoMan()
     void onRepoActivated(RM::Repo* repo);
     void onRepoDeactivated(RM::Repo* repo);
 
+private slots:
+    void fetchOperationFinished();
+
 private:
     QModelIndex deeplyMapToSource( QModelIndex current ) const;
     BlueSky::ViewContext* createContextObject() const;

--- a/Repository/RepoTreeView.hpp
+++ b/Repository/RepoTreeView.hpp
@@ -46,6 +46,8 @@ private slots:  // from actions
     void onCtxActivate();
     void onCtxClose();
 
+    void onCtxFetchAll();
+
 private slots:  // from mRepos
     void contextMenu( const QModelIndex& index, const QPoint& globalPos );
 

--- a/Repository/RepoTreeViewCtxMenu.hid
+++ b/Repository/RepoTreeViewCtxMenu.hid
@@ -16,8 +16,6 @@
 
 Ui RepoTreeViewCtxMenu {
 
-
-
     Action Activate {
         Text            "&Activate";
         StatusToolTip   "Make this repository the active one.";
@@ -30,9 +28,24 @@ Ui RepoTreeViewCtxMenu {
         ConnectTo       onCtxClose();
     };
 
+
+    Action FetchAll {
+        Text            "All Remotes";
+        StatusToolTip   "Fetch repository changes from all remotes.";
+    };
+
+
+    Menu MenuFetch {
+        Text            "Fetch";
+        Action          FetchAll;
+        Separator;
+    };
+
     Menu CtxMenuRepo {
 
         Action      Activate;
+        Separator;
+        Menu        MenuFetch;
         Separator;
         Action      Close;
 

--- a/Repository/RepoTreeViewCtxMenu.hid
+++ b/Repository/RepoTreeViewCtxMenu.hid
@@ -32,6 +32,7 @@ Ui RepoTreeViewCtxMenu {
     Action FetchAll {
         Text            "All Remotes";
         StatusToolTip   "Fetch repository changes from all remotes.";
+        ConnectTo       onCtxFetchAll();
     };
 
 

--- a/Repository/RepoTreeViewCtxMenu.hid
+++ b/Repository/RepoTreeViewCtxMenu.hid
@@ -55,6 +55,8 @@ Ui RepoTreeViewCtxMenu {
     Menu CtxMenuSMRepo {
 
         Action      Activate;
+        Separator;
+        Menu        MenuFetch;
 
     };
 


### PR DESCRIPTION
**Some thoughts about this PR:**
It is not a good idea to realize the remotes menu in a central place. Why? Because from a users point of view there is no obvious context (What am I fetching/pushing from/to where? To which repository will a new remote belong?). Also the options to the fetch process are context-specific. The actions should actually be added to the appropriate context menus. For example a "fetch action" on a remote branch, fetches the remote branch. IOW: This belongs to the Reference-Tree and probably to the inline remote references in the History-View (we don't have a context menu for them yet). The actions itself should be defined central in the "Remotes" module, which should provide a the generic remote operations and just needs to be attached to the appropriate context. For this reason, the concept of the DAM (Dynamic Action Merger) has to be fully implemented first. This PR has to be hold back until then. 

**This is how it could look like?**
![mgv-fetch-repo-ctx-menu](https://cloud.githubusercontent.com/assets/440517/6541925/c2c85d1a-c4e8-11e4-9324-85fe4b2a21d3.png)

**Planned for this PR:**
- [x] Fetch all remotes.
- [x] ~~Fetch a single remote (only when more that one remote are configured)~~
  :memo: Another PR will be created for this after integrating the MacGitverModules submodule. 

**Excluded from this PR**
- Move actions from "Remotes" application menu to the appropriate context menus.
- Fetch a single branch.
  This is planned as an action for the "Reference-Tree" (and the inline references in "History-View"). See ticket on ![Redmine]()

**More Ideas**:
- Prune remotely deleted branches (aka `git fetch --prune`).
  One idea is, to provide a "Cleanup" context menu to the repository tree, with options "Prune Branches", "Garbage Collection (gc)", ...
- add a flag or option to recurse into submodules -> this clashes somewhat with the `git config.fetch.recurseSubmodules` flag.
