### PR TITLE
WorkTree/Index: add keyboard shortcuts for stage, unstage and reset

### DIFF
--- a/WorkingTree/StageViewCtxMenu.hid
+++ b/WorkingTree/StageViewCtxMenu.hid
@@ -19,6 +19,8 @@ Ui StageViewCtxMenu {
     Action Unstage {
         Text            "&Unstage";
         StatusToolTip   "Unmark this file from committing.";
+        Shortcut        "Ctrl+U";
+        ShortcutContext WidgetShortcut;
         ConnectTo       onWtCtxUnstage();
     };
 

--- a/WorkingTree/WorkingTreeCtxMenu.hid
+++ b/WorkingTree/WorkingTreeCtxMenu.hid
@@ -19,12 +19,16 @@ Ui WorkingTreeCtxMenu {
     Action Stage {
         Text            "&Stage";
         StatusToolTip   "Mark this file ready to commit.";
+        Shortcut        "Ctrl+T";
+        ShortcutContext WidgetShortcut;
         ConnectTo       onWtCtxStage();
     };
 
     Action Reset {
         Text            "&Discard changes";
         StatusToolTip   "Discard unstaged changes to this file.";
+        Shortcut        "Ctrl+J";
+        ShortcutContext WidgetShortcut;
         ConnectTo       onWtCtxDiscard();
     };
 


### PR DESCRIPTION
The shortcuts should match git-gui:

Ctrl+T = stage file
Ctrl+U = unstage file
Ctrl+J = reset file changes

Seems, that HIC (libHeaven) needs some love to make this actually work :). I'd like to merge this anyways. 
