### PR TITLE
Realization of remote actions in "Remotes" Module

### DIFF
--- a/Remotes/RemoteCreateEditDlg.ui
+++ b/Remotes/RemoteCreateEditDlg.ui
@@ -6,75 +6,58 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>428</width>
-    <height>307</height>
+    <width>438</width>
+    <height>340</height>
    </rect>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Remote Server</string>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>URL</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Url</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtUrl</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="LineEdit" name="txtUrl">
-        <property name="mandatory" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Name</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtName</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="LineEdit" name="txtName">
-        <property name="mandatory" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="chkPushUrl">
-        <property name="text">
-         <string>Push Url</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="LineEdit" name="txtPushUrl">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="mandatory" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>txtUrl</cstring>
+     </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="1" column="1">
+    <widget class="LineEdit" name="txtUrl">
+     <property name="placeholderText">
+      <string>Enter the full URI to the remote repository</string>
+     </property>
+     <property name="mandatory" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="LineEdit" name="txtPushUrl">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="mandatory" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
     <widget class="QGroupBox" name="chkRefSpecs">
      <property name="title">
-      <string>Custom refspec for Fetch</string>
+      <string>Custom refspecs for Fetch</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -139,13 +122,36 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Alias</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>txtName</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="LineEdit" name="txtName">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>Enter an alias for the Git Remote ...</string>
+     </property>
+     <property name="mandatory" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="chkPushUrl">
+     <property name="text">
+      <string>Push URL</string>
      </property>
     </widget>
    </item>
@@ -159,10 +165,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>txtName</tabstop>
-  <tabstop>txtUrl</tabstop>
-  <tabstop>chkPushUrl</tabstop>
-  <tabstop>txtPushUrl</tabstop>
   <tabstop>chkRefSpecs</tabstop>
   <tabstop>treeRefSpecs</tabstop>
   <tabstop>txtEditRefSpec</tabstop>

--- a/Remotes/RemotesModule.cpp
+++ b/Remotes/RemotesModule.cpp
@@ -35,7 +35,6 @@ BlueSky::View* RemotesModule::createRemotesView()
 void RemotesModule::initialize()
 {
     setupActions( this );
-    acRemotesAC->mergeInto( "RemotesMP" );
 
     MacGitver::self().registerView( "Remotes", tr( "Remotes" ),
                                     &RemotesModule::createRemotesView );

--- a/Remotes/RemotesModule.cpp
+++ b/Remotes/RemotesModule.cpp
@@ -36,6 +36,7 @@ void RemotesModule::initialize()
 {
     setupActions( this );
 
+     acRemotesAC->mergeInto( "RemotesMP" );
      acRemotesFetchAC->mergeInto( "RemotesFetchMP" );
 
     MacGitver::self().registerView( "Remotes", tr( "Remotes" ),
@@ -47,9 +48,17 @@ void RemotesModule::deinitialize()
     MacGitver::self().unregisterView( "Remotes" );
 }
 
-void RemotesModule::onRemoteCreate()
+/**
+ * @brief       Menu action to create a remote and add it to a repository.
+ */
+void RemotesModule::onRemoteCreateEdit()
 {
-    RemoteCreateEditDlg().exec();
+    // TODO: requires a repository context (the repo to add the remote to)
+    // To edit an existing remote, the remote context is required
+    RemoteCreateEditDlg dlg;
+    //TODO: dlg.setContext( ctx );
+    dlg.exec();
+}
 }
 
 /**

--- a/Remotes/RemotesModule.cpp
+++ b/Remotes/RemotesModule.cpp
@@ -16,8 +16,12 @@
 
 #include <QtPlugin>
 #include <QFileDialog>
+#include <QMessageBox>
+
+#include "libGitWrap/Operations/RemoteOperations.hpp"
 
 #include "libMacGitverCore/App/MacGitver.hpp"
+#include "libMacGitverCore/RepoMan/Repo.hpp"
 
 #include "RemoteCreateEditDlg.h"
 #include "RemotesModule.h"
@@ -59,6 +63,10 @@ void RemotesModule::onRemoteCreateEdit()
     //TODO: dlg.setContext( ctx );
     dlg.exec();
 }
+
+void RemotesModule::onRemoteDelete()
+{
+    // TODO: requires the remote context (the remote to delete)
 }
 
 /**
@@ -66,8 +74,59 @@ void RemotesModule::onRemoteCreateEdit()
  */
 void RemotesModule::onRemotesFetchAll()
 {
-    // TODO: requires a RepositoryContext (the repo to fetch all remotes from)
+    // TODO: requires a repository context (the repo to fetch all remotes from)
     // A sub-context (i.e. a branch) can further restrict, what is fetched
+    Heaven::Action* action = qobject_cast< Heaven::Action* >( sender() );
+    Q_ASSERT( action );
+    RM::Repo* repo = qobject_cast< RM::Repo* >( action->activatedBy() );
+    if( repo ) {
+        Git::Result r;
+        Git::Repository gitRepo = repo->gitRepo();
+        const QStringList aliases( gitRepo.allRemoteNames(r) );
+        if ( !r ) {
+            QMessageBox::warning( 0, tr("Lookup of remotes failed"),
+                                  tr("Unable to lookup remotes for repository '%1'."
+                                     "\nMessage: %2").arg(repo->displayName())
+                                  .arg(r.errorText())
+                                  );
+            return;
+        }
+
+        if ( aliases.isEmpty() ) {
+            QMessageBox::information( 0, tr("No Remotes found"),
+                                      tr("No remotes configured for repository '%1'.")
+                                      .arg(repo->displayName())
+                                      );
+            return;
+        }
+
+        foreach (const QString& alias, aliases) {
+            Git::FetchOperation* op = new Git::FetchOperation( repo->gitRepo() );
+            op->setRemoteAlias( alias );
+            op->setBackgroundMode( true );
+            connect( op, SIGNAL(finished()), this, SLOT(fetchOperationFinished()) );
+            // TODO: create a central dialog to show progress of parallel operations
+            op->execute();
+        }
+    }
+}
+
+/**
+ * @brief       Called, when an non-blocking Git::Operation finished.
+ */
+void RemotesModule::onOperationFinished()
+{
+    Git::BaseOperation* op = qobject_cast<Git::BaseOperation*>( sender() );
+    Q_ASSERT( op );
+    Git::Result r( op->result() );
+    if ( !r ) {
+        QMessageBox::warning( 0, tr("Operation failed."),
+                              tr("Operation failed. Message:\n %1").arg(r.errorText())
+                              );
+    }
+
+    // delete the operation
+    op->deleteLater();
 }
 
 #if QT_VERSION < 0x050000

--- a/Remotes/RemotesModule.cpp
+++ b/Remotes/RemotesModule.cpp
@@ -36,6 +36,8 @@ void RemotesModule::initialize()
 {
     setupActions( this );
 
+     acRemotesFetchAC->mergeInto( "RemotesFetchMP" );
+
     MacGitver::self().registerView( "Remotes", tr( "Remotes" ),
                                     &RemotesModule::createRemotesView );
 }
@@ -48,6 +50,15 @@ void RemotesModule::deinitialize()
 void RemotesModule::onRemoteCreate()
 {
     RemoteCreateEditDlg().exec();
+}
+
+/**
+ * @brief       Menu action to fetch all remotes of a repository.
+ */
+void RemotesModule::onRemotesFetchAll()
+{
+    // TODO: requires a RepositoryContext (the repo to fetch all remotes from)
+    // A sub-context (i.e. a branch) can further restrict, what is fetched
 }
 
 #if QT_VERSION < 0x050000

--- a/Remotes/RemotesModule.h
+++ b/Remotes/RemotesModule.h
@@ -38,7 +38,8 @@ private:
     static BlueSky::View* createRemotesView();
 
 private slots:
-    void onRemoteCreate();
+    // RemotesAC
+    void onRemoteCreateEdit();
 
 private slots:
     // RemotesFetchAC

--- a/Remotes/RemotesModule.h
+++ b/Remotes/RemotesModule.h
@@ -40,10 +40,14 @@ private:
 private slots:
     // RemotesAC
     void onRemoteCreateEdit();
+    void onRemoteDelete();
 
 private slots:
     // RemotesFetchAC
     void onRemotesFetchAll();
+
+private slots:
+    void onOperationFinished();
 };
 
 #endif

--- a/Remotes/RemotesModule.h
+++ b/Remotes/RemotesModule.h
@@ -39,6 +39,10 @@ private:
 
 private slots:
     void onRemoteCreate();
+
+private slots:
+    // RemotesFetchAC
+    void onRemotesFetchAll();
 };
 
 #endif

--- a/Remotes/RemotesModuleActions.hid
+++ b/Remotes/RemotesModuleActions.hid
@@ -21,7 +21,18 @@ Ui RemotesModuleActions {
 
 
 
+    Container RemotesFetchAC {
 
+        Menu MnuFetch {
+            Text    "Fetch";
 
+            Action RemotesFetchAll {
+                Text        "All Remotes";
+                _ConnectTo  onRemotesFetchAll();
+            };
+            Separator;
+        };
+
+    };
 
 };

--- a/Remotes/RemotesModuleActions.hid
+++ b/Remotes/RemotesModuleActions.hid
@@ -16,27 +16,12 @@
 
 Ui RemotesModuleActions {
 
-    Container RemotesAC {
 
-        Menu Remotes {
 
-            Text    "R&emotes";
 
-            Action RemotesCreate {
-                Text        "&Create...";
-                _ConnectTo  onRemoteCreate();
-            };
 
-            Action RemotesFetch {
-                Text        "&Fetch";
-            };
 
-            Action RemotesPush {
-                Text        "P&ush...";
-            };
 
-        };
 
-    };
 
 };

--- a/Remotes/RemotesModuleActions.hid
+++ b/Remotes/RemotesModuleActions.hid
@@ -16,10 +16,19 @@
 
 Ui RemotesModuleActions {
 
+    Container RemotesAC {
+
+        Menu MnuRemotes {
+            Text    "Remotes";
+
+            Action RemoteAdd {
+                Text        "Add Remote ...";
+                _ConnectTo  onRemoteCreateEdit();
+            };
 
 
-
-
+        };
+    };
 
     Container RemotesFetchAC {
 

--- a/Repository/RepoTreeViewCtxMenu.hid
+++ b/Repository/RepoTreeViewCtxMenu.hid
@@ -16,8 +16,6 @@
 
 Ui RepoTreeViewCtxMenu {
 
-
-
     Action Activate {
         Text            "&Activate";
         StatusToolTip   "Make this repository the active one.";
@@ -33,6 +31,9 @@ Ui RepoTreeViewCtxMenu {
     Menu CtxMenuRepo {
 
         Action      Activate;
+        Separator;
+        MergePlace  RemotesMP;
+        MergePlace  RemotesFetchMP;
         Separator;
         Action      Close;
 


### PR DESCRIPTION
The single purpose of this PR is to realize (complete) the abstraction layer for user actions to a repository's remote components. This affects the remote operations "fetch", "push", "clone" and "pull".

The focus is clearly on the **fetch operation** first. The already existing clone operation has to be also integrated here, but this is another topic and works as is.
